### PR TITLE
Use FFI types to enforce sane resolution values.

### DIFF
--- a/lib/h3/bindings.rb
+++ b/lib/h3/bindings.rb
@@ -1,5 +1,6 @@
 require "h3/bindings/base"
 require "h3/bindings/structs"
+require "h3/bindings/types"
 require "h3/bindings/private"
 
 module H3

--- a/lib/h3/bindings/base.rb
+++ b/lib/h3/bindings/base.rb
@@ -6,8 +6,14 @@ module H3
     module Base
       def self.extended(base)
         base.extend FFI::Library
+        base.include Structs
+        base.include Types
         base.ffi_lib ["libh3", "libh3.1"]
         base.typedef :ulong_long, :h3_index
+        base.typedef :int, :size
+        base.typedef :int, :k_distance
+        base.typedef :pointer, :h3_set
+        base.typedef :pointer, :output_buffer
         base.const_set("H3_INDEX", :ulong_long)
       end
     end

--- a/lib/h3/bindings/private.rb
+++ b/lib/h3/bindings/private.rb
@@ -7,46 +7,46 @@ module H3
     module Private
       extend H3::Bindings::Base
 
-      attach_function :compact, %i[pointer pointer int], :bool
-      attach_function :geo_to_h3, :geoToH3, [Bindings::Structs::GeoCoord.by_ref, :int], :h3_index
+      attach_function :compact, %i[h3_set output_buffer size], :bool
+      attach_function :geo_to_h3, :geoToH3, [GeoCoord.by_ref, Resolution], :h3_index
       attach_function :h3_indexes_from_unidirectional_edge,
                       :getH3IndexesFromUnidirectionalEdge,
-                      %i[h3_index pointer], :void
+                      %i[h3_index output_buffer], :void
       attach_function :h3_unidirectional_edges_from_hexagon,
                       :getH3UnidirectionalEdgesFromHexagon,
-                      %i[h3_index pointer], :void
+                      %i[h3_index output_buffer], :void
       attach_function :h3_set_to_linked_geo,
                       :h3SetToLinkedGeo,
-                      [:pointer, :int, Bindings::Structs::LinkedGeoPolygon.by_ref],
+                      [:h3_set, :size, LinkedGeoPolygon.by_ref],
                       :void
-      attach_function :h3_to_children, :h3ToChildren, %i[h3_index int pointer], :void
-      attach_function :h3_to_geo, :h3ToGeo, [:h3_index, Bindings::Structs::GeoCoord.by_ref], :void
-      attach_function :h3_to_string, :h3ToString, %i[h3_index pointer int], :void
+      attach_function :h3_to_children, :h3ToChildren, [:h3_index, Resolution, :output_buffer], :void
+      attach_function :h3_to_geo, :h3ToGeo, [:h3_index, GeoCoord.by_ref], :void
+      attach_function :h3_to_string, :h3ToString, %i[h3_index output_buffer size], :void
       attach_function :h3_to_geo_boundary,
                       :h3ToGeoBoundary,
-                      [:h3_index, Bindings::Structs::GeoBoundary.by_ref],
+                      [:h3_index, GeoBoundary.by_ref],
                       :void
       attach_function :h3_unidirectional_edge_boundary,
                       :getH3UnidirectionalEdgeBoundary,
-                      %i[h3_index pointer], :void
-      attach_function :hex_range, :hexRange, %i[h3_index int pointer], :bool
+                      %i[h3_index output_buffer], :void
+      attach_function :hex_range, :hexRange, %i[h3_index k_distance output_buffer], :bool
       attach_function :hex_range_distances,
                       :hexRangeDistances,
-                      %i[h3_index int pointer pointer], :bool
-      attach_function :hex_ranges, :hexRanges, %i[pointer int int pointer], :bool
-      attach_function :hex_ring, :hexRing, %i[h3_index int pointer], :bool
-      attach_function :k_ring, :kRing, %i[h3_index int pointer], :void
+                      %i[h3_index k_distance output_buffer output_buffer], :bool
+      attach_function :hex_ranges, :hexRanges, %i[h3_set size k_distance output_buffer], :bool
+      attach_function :hex_ring, :hexRing, %i[h3_index k_distance output_buffer], :bool
+      attach_function :k_ring, :kRing, %i[h3_index k_distance output_buffer], :void
       attach_function :k_ring_distances,
                       :kRingDistances,
-                      %i[h3_index int pointer pointer],
+                      %i[h3_index k_distance output_buffer output_buffer],
                       :bool
       attach_function :max_polyfill_size,
                       :maxPolyfillSize,
-                      [Bindings::Structs::GeoPolygon.by_ref, :int],
+                      [GeoPolygon.by_ref, Resolution],
                       :int
-      attach_function :max_uncompact_size, :maxUncompactSize, %i[pointer int int], :int
-      attach_function :polyfill, %i[pointer int pointer], :void
-      attach_function :uncompact, %i[pointer int pointer int int], :bool
+      attach_function :max_uncompact_size, :maxUncompactSize, [:h3_set, :size, Resolution], :int
+      attach_function :polyfill, [GeoPolygon.by_ref, Resolution, :output_buffer], :void
+      attach_function :uncompact, [:h3_set, :size, :output_buffer, :size, Resolution], :bool
     end
   end
 end

--- a/lib/h3/bindings/types.rb
+++ b/lib/h3/bindings/types.rb
@@ -5,11 +5,11 @@ module H3
         extend FFI::DataConverter
         native_type FFI::Type::INT
 
-        RES_RANGE = [0, 15].freeze
+        RES_RANGE = 0..15
 
         class << self
           def to_native(value, _context)
-            failure unless value.is_a?(Integer) && value.between?(*RES_RANGE)
+            failure unless value.is_a?(Integer) && RES_RANGE.cover?(value)
             value
           end
 

--- a/lib/h3/bindings/types.rb
+++ b/lib/h3/bindings/types.rb
@@ -1,0 +1,26 @@
+module H3
+  module Bindings
+    module Types
+      class Resolution
+        extend FFI::DataConverter
+        native_type FFI::Type::INT
+
+        RES_RANGE = [0, 15].freeze
+
+        class << self
+          def to_native(value, _context)
+            failure unless value.is_a?(Integer) && value.between?(*RES_RANGE)
+            value
+          end
+
+          private
+
+          def failure
+            raise ArgumentError, 
+                  "resolution must be between #{RES_RANGE.first} and #{RES_RANGE.last}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/h3/hierarchy.rb
+++ b/lib/h3/hierarchy.rb
@@ -17,7 +17,7 @@ module H3
     #   604189371209351167
     #
     # @return [Integer] H3 index of parent hexagon.
-    attach_function :h3_to_parent, :h3ToParent, %i[h3_index int], :h3_index
+    attach_function :h3_to_parent, :h3ToParent, [:h3_index, Resolution], :h3_index
 
     # @!method max_h3_to_children_size(h3_index, child_resolution)
     #
@@ -31,7 +31,7 @@ module H3
     #    49
     #
     # @return [Integer] Maximum number of child hexagons possible at given resolution.
-    attach_function :max_h3_to_children_size, :maxH3ToChildrenSize, %i[h3_index int], :int
+    attach_function :max_h3_to_children_size, :maxH3ToChildrenSize, [:h3_index, Resolution], :int
 
     # Derive child hexagons contained within the hexagon at the given H3 index.
     #

--- a/lib/h3/inspection.rb
+++ b/lib/h3/inspection.rb
@@ -19,7 +19,7 @@ module H3
     #   9
     #
     # @return [Integer] Resolution of H3 index
-    attach_function :h3_resolution, :h3GetResolution, %i[h3_index], :int
+    attach_function :h3_resolution, :h3GetResolution, %i[h3_index], Resolution
 
     # @!method h3_base_cell(h3_index)
     #

--- a/lib/h3/traversal.rb
+++ b/lib/h3/traversal.rb
@@ -16,7 +16,7 @@ module H3
     #   91
     #
     # @return [Integer] Maximum k-ring size.
-    attach_function :max_kring_size, :maxKringSize, %i[int], :int
+    attach_function :max_kring_size, :maxKringSize, %i[k_distance], :int
 
     # @!method h3_distance(origin, h3_index)
     #
@@ -30,7 +30,7 @@ module H3
     #   5
     #
     # @return [Integer] Distance between indexes.
-    attach_function :h3_distance, :h3Distance, %i[h3_index h3_index], :int
+    attach_function :h3_distance, :h3Distance, %i[h3_index h3_index], :k_distance
 
     # Derives H3 indexes within k distance of the origin H3 index.
     #

--- a/spec/hierarchy_spec.rb
+++ b/spec/hierarchy_spec.rb
@@ -56,6 +56,22 @@ RSpec.describe H3 do
         expect(h3_to_children.count).to eq count
       end
     end
+
+    context "when the resolution is -1" do
+      let(:child_resolution) { -1 }
+
+      it "raises an error" do
+        expect { h3_to_children }.to raise_error(ArgumentError)
+      end
+    end
+
+    context "when the resolution is 16" do
+      let(:child_resolution) { 16 }
+
+      it "raises an error" do
+        expect { h3_to_children }.to raise_error(ArgumentError)
+      end
+    end
   end
 
   describe ".max_h3_to_children_size" do


### PR DESCRIPTION
Also includes some changes to make the `attach_function` more readable i.e. alias `int` and `pointer` to more descriptive values.