### PR TITLE
Various Refactorings

### DIFF
--- a/lib/h3.rb
+++ b/lib/h3.rb
@@ -34,7 +34,7 @@ module H3
                     h3_unidirectional_edge_valid h3_valid].freeze
     private_constant :PREDICATES
     PREDICATES.each do |predicate|
-      alias_method "#{predicate}?".to_sym, predicate
+      alias_method "#{predicate}?", predicate
       undef_method predicate
     end
   end

--- a/lib/h3.rb
+++ b/lib/h3.rb
@@ -26,12 +26,16 @@ module H3
     include Regions
     include Traversal
     include UnidirectionalEdges
-  end
 
-  PREDICATES = %i[h3_indexes_neighbors h3_pentagon h3_res_class_3
-                  h3_unidirectional_edge_valid h3_valid].freeze
-  private_constant :PREDICATES
-  PREDICATES.each do |predicate|
-    singleton_class.send(:alias_method, "#{predicate}?".to_sym, predicate)
+    # FFI's attach_function doesn't allow method names ending with a
+    # question mark. This works around the issue by dynamically
+    # renaming those methods afterwards.
+    PREDICATES = %i[h3_indexes_neighbors h3_pentagon h3_res_class_3
+                    h3_unidirectional_edge_valid h3_valid].freeze
+    private_constant :PREDICATES
+    PREDICATES.each do |predicate|
+      alias_method "#{predicate}?".to_sym, predicate
+      undef_method predicate
+    end
   end
 end

--- a/lib/h3/bindings/private.rb
+++ b/lib/h3/bindings/private.rb
@@ -7,20 +7,20 @@ module H3
     module Private
       extend H3::Bindings::Base
 
-      attach_function :compact, [H3SetIn, :output_buffer, :size], :bool
+      attach_function :compact, [H3SetIn, H3SetOut, :size], :bool
       attach_function :geo_to_h3, :geoToH3, [GeoCoord.by_ref, Resolution], :h3_index
       attach_function :h3_indexes_from_unidirectional_edge,
                       :getH3IndexesFromUnidirectionalEdge,
-                      %i[h3_index output_buffer], :void
-      attach_function :h3_line, :h3Line, %i[h3_index h3_index output_buffer], :int
+                      [:h3_index, H3SetOut], :void
+      attach_function :h3_line, :h3Line, [:h3_index, :h3_index, H3SetOut], :int
       attach_function :h3_unidirectional_edges_from_hexagon,
                       :getH3UnidirectionalEdgesFromHexagon,
-                      %i[h3_index output_buffer], :void
+                      [:h3_index, H3SetOut], :void
       attach_function :h3_set_to_linked_geo,
                       :h3SetToLinkedGeo,
                       [H3SetIn, :size, LinkedGeoPolygon.by_ref],
                       :void
-      attach_function :h3_to_children, :h3ToChildren, [:h3_index, Resolution, :output_buffer], :void
+      attach_function :h3_to_children, :h3ToChildren, [:h3_index, Resolution, H3SetOut], :void
       attach_function :h3_to_geo, :h3ToGeo, [:h3_index, GeoCoord.by_ref], :void
       attach_function :h3_to_string, :h3ToString, %i[h3_index output_buffer size], :void
       attach_function :h3_to_geo_boundary,
@@ -29,25 +29,25 @@ module H3
                       :void
       attach_function :h3_unidirectional_edge_boundary,
                       :getH3UnidirectionalEdgeBoundary,
-                      %i[h3_index output_buffer], :void
-      attach_function :hex_range, :hexRange, %i[h3_index k_distance output_buffer], :bool
+                      [:h3_index, GeoBoundary.by_ref], :void
+      attach_function :hex_range, :hexRange, [:h3_index, :k_distance, H3SetOut], :bool
       attach_function :hex_range_distances,
                       :hexRangeDistances,
-                      %i[h3_index k_distance output_buffer output_buffer], :bool
-      attach_function :hex_ranges, :hexRanges, [H3SetIn, :size, :k_distance, :output_buffer], :bool
-      attach_function :hex_ring, :hexRing, %i[h3_index k_distance output_buffer], :bool
-      attach_function :k_ring, :kRing, %i[h3_index k_distance output_buffer], :void
+                      [:h3_index, :k_distance, H3SetOut, :output_buffer], :bool
+      attach_function :hex_ranges, :hexRanges, [H3SetIn, :size, :k_distance, H3SetOut], :bool
+      attach_function :hex_ring, :hexRing, [:h3_index, :k_distance, H3SetOut], :bool
+      attach_function :k_ring, :kRing, [:h3_index, :k_distance, H3SetOut], :void
       attach_function :k_ring_distances,
                       :kRingDistances,
-                      %i[h3_index k_distance output_buffer output_buffer],
+                      [:h3_index, :k_distance, H3SetOut, :output_buffer],
                       :bool
       attach_function :max_polyfill_size,
                       :maxPolyfillSize,
                       [GeoPolygon.by_ref, Resolution],
                       :int
       attach_function :max_uncompact_size, :maxUncompactSize, [H3SetIn, :size, Resolution], :int
-      attach_function :polyfill, [GeoPolygon.by_ref, Resolution, :output_buffer], :void
-      attach_function :uncompact, [H3SetIn, :size, :output_buffer, :size, Resolution], :bool
+      attach_function :polyfill, [GeoPolygon.by_ref, Resolution, H3SetOut], :void
+      attach_function :uncompact, [H3SetIn, :size, H3SetOut, :size, Resolution], :bool
     end
   end
 end

--- a/lib/h3/bindings/private.rb
+++ b/lib/h3/bindings/private.rb
@@ -8,7 +8,7 @@ module H3
       extend H3::Bindings::Base
 
       attach_function :compact, [H3IndexesIn, H3IndexesOut, :size], :bool
-      attach_function :geo_to_h3, :geoToH3, [GeoCoord.by_ref, Resolution], :h3_index
+      attach_function :geo_to_h3, :geoToH3, [GeoCoord, Resolution], :h3_index
       attach_function :h3_indexes_from_unidirectional_edge,
                       :getH3IndexesFromUnidirectionalEdge,
                       [:h3_index, H3IndexesOut], :void
@@ -18,18 +18,18 @@ module H3
                       [:h3_index, H3IndexesOut], :void
       attach_function :h3_set_to_linked_geo,
                       :h3SetToLinkedGeo,
-                      [H3IndexesIn, :size, LinkedGeoPolygon.by_ref],
+                      [H3IndexesIn, :size, LinkedGeoPolygon],
                       :void
       attach_function :h3_to_children, :h3ToChildren, [:h3_index, Resolution, H3IndexesOut], :void
-      attach_function :h3_to_geo, :h3ToGeo, [:h3_index, GeoCoord.by_ref], :void
+      attach_function :h3_to_geo, :h3ToGeo, [:h3_index, GeoCoord], :void
       attach_function :h3_to_string, :h3ToString, %i[h3_index output_buffer size], :void
       attach_function :h3_to_geo_boundary,
                       :h3ToGeoBoundary,
-                      [:h3_index, GeoBoundary.by_ref],
+                      [:h3_index, GeoBoundary],
                       :void
       attach_function :h3_unidirectional_edge_boundary,
                       :getH3UnidirectionalEdgeBoundary,
-                      [:h3_index, GeoBoundary.by_ref], :void
+                      [:h3_index, GeoBoundary], :void
       attach_function :hex_range, :hexRange, [:h3_index, :k_distance, H3IndexesOut], :bool
       attach_function :hex_range_distances,
                       :hexRangeDistances,
@@ -43,7 +43,7 @@ module H3
                       :bool
       attach_function :max_polyfill_size,
                       :maxPolyfillSize,
-                      [GeoPolygon.by_ref, Resolution],
+                      [GeoPolygon, Resolution],
                       :int
       attach_function :max_uncompact_size, :maxUncompactSize, [H3IndexesIn, :size, Resolution], :int
       attach_function :polyfill, [GeoPolygon.by_ref, Resolution, H3IndexesOut], :void

--- a/lib/h3/bindings/private.rb
+++ b/lib/h3/bindings/private.rb
@@ -7,20 +7,20 @@ module H3
     module Private
       extend H3::Bindings::Base
 
-      attach_function :compact, [H3SetIn, H3SetOut, :size], :bool
+      attach_function :compact, [H3IndexesIn, H3IndexesOut, :size], :bool
       attach_function :geo_to_h3, :geoToH3, [GeoCoord.by_ref, Resolution], :h3_index
       attach_function :h3_indexes_from_unidirectional_edge,
                       :getH3IndexesFromUnidirectionalEdge,
-                      [:h3_index, H3SetOut], :void
-      attach_function :h3_line, :h3Line, [:h3_index, :h3_index, H3SetOut], :int
+                      [:h3_index, H3IndexesOut], :void
+      attach_function :h3_line, :h3Line, [:h3_index, :h3_index, H3IndexesOut], :int
       attach_function :h3_unidirectional_edges_from_hexagon,
                       :getH3UnidirectionalEdgesFromHexagon,
-                      [:h3_index, H3SetOut], :void
+                      [:h3_index, H3IndexesOut], :void
       attach_function :h3_set_to_linked_geo,
                       :h3SetToLinkedGeo,
-                      [H3SetIn, :size, LinkedGeoPolygon.by_ref],
+                      [H3IndexesIn, :size, LinkedGeoPolygon.by_ref],
                       :void
-      attach_function :h3_to_children, :h3ToChildren, [:h3_index, Resolution, H3SetOut], :void
+      attach_function :h3_to_children, :h3ToChildren, [:h3_index, Resolution, H3IndexesOut], :void
       attach_function :h3_to_geo, :h3ToGeo, [:h3_index, GeoCoord.by_ref], :void
       attach_function :h3_to_string, :h3ToString, %i[h3_index output_buffer size], :void
       attach_function :h3_to_geo_boundary,
@@ -30,24 +30,24 @@ module H3
       attach_function :h3_unidirectional_edge_boundary,
                       :getH3UnidirectionalEdgeBoundary,
                       [:h3_index, GeoBoundary.by_ref], :void
-      attach_function :hex_range, :hexRange, [:h3_index, :k_distance, H3SetOut], :bool
+      attach_function :hex_range, :hexRange, [:h3_index, :k_distance, H3IndexesOut], :bool
       attach_function :hex_range_distances,
                       :hexRangeDistances,
-                      [:h3_index, :k_distance, H3SetOut, :output_buffer], :bool
-      attach_function :hex_ranges, :hexRanges, [H3SetIn, :size, :k_distance, H3SetOut], :bool
-      attach_function :hex_ring, :hexRing, [:h3_index, :k_distance, H3SetOut], :bool
-      attach_function :k_ring, :kRing, [:h3_index, :k_distance, H3SetOut], :void
+                      [:h3_index, :k_distance, H3IndexesOut, :output_buffer], :bool
+      attach_function :hex_ranges, :hexRanges, [H3IndexesIn, :size, :k_distance, H3IndexesOut], :bool
+      attach_function :hex_ring, :hexRing, [:h3_index, :k_distance, H3IndexesOut], :bool
+      attach_function :k_ring, :kRing, [:h3_index, :k_distance, H3IndexesOut], :void
       attach_function :k_ring_distances,
                       :kRingDistances,
-                      [:h3_index, :k_distance, H3SetOut, :output_buffer],
+                      [:h3_index, :k_distance, H3IndexesOut, :output_buffer],
                       :bool
       attach_function :max_polyfill_size,
                       :maxPolyfillSize,
                       [GeoPolygon.by_ref, Resolution],
                       :int
-      attach_function :max_uncompact_size, :maxUncompactSize, [H3SetIn, :size, Resolution], :int
-      attach_function :polyfill, [GeoPolygon.by_ref, Resolution, H3SetOut], :void
-      attach_function :uncompact, [H3SetIn, :size, H3SetOut, :size, Resolution], :bool
+      attach_function :max_uncompact_size, :maxUncompactSize, [H3IndexesIn, :size, Resolution], :int
+      attach_function :polyfill, [GeoPolygon.by_ref, Resolution, H3IndexesOut], :void
+      attach_function :uncompact, [H3IndexesIn, :size, H3IndexesOut, :size, Resolution], :bool
     end
   end
 end

--- a/lib/h3/bindings/private.rb
+++ b/lib/h3/bindings/private.rb
@@ -7,7 +7,7 @@ module H3
     module Private
       extend H3::Bindings::Base
 
-      attach_function :compact, %i[h3_set output_buffer size], :bool
+      attach_function :compact, [H3SetIn, :output_buffer, :size], :bool
       attach_function :geo_to_h3, :geoToH3, [GeoCoord.by_ref, Resolution], :h3_index
       attach_function :h3_indexes_from_unidirectional_edge,
                       :getH3IndexesFromUnidirectionalEdge,
@@ -18,7 +18,7 @@ module H3
                       %i[h3_index output_buffer], :void
       attach_function :h3_set_to_linked_geo,
                       :h3SetToLinkedGeo,
-                      [:h3_set, :size, LinkedGeoPolygon.by_ref],
+                      [H3SetIn, :size, LinkedGeoPolygon.by_ref],
                       :void
       attach_function :h3_to_children, :h3ToChildren, [:h3_index, Resolution, :output_buffer], :void
       attach_function :h3_to_geo, :h3ToGeo, [:h3_index, GeoCoord.by_ref], :void
@@ -34,7 +34,7 @@ module H3
       attach_function :hex_range_distances,
                       :hexRangeDistances,
                       %i[h3_index k_distance output_buffer output_buffer], :bool
-      attach_function :hex_ranges, :hexRanges, %i[h3_set size k_distance output_buffer], :bool
+      attach_function :hex_ranges, :hexRanges, [H3SetIn, :size, :k_distance, :output_buffer], :bool
       attach_function :hex_ring, :hexRing, %i[h3_index k_distance output_buffer], :bool
       attach_function :k_ring, :kRing, %i[h3_index k_distance output_buffer], :void
       attach_function :k_ring_distances,
@@ -45,9 +45,9 @@ module H3
                       :maxPolyfillSize,
                       [GeoPolygon.by_ref, Resolution],
                       :int
-      attach_function :max_uncompact_size, :maxUncompactSize, [:h3_set, :size, Resolution], :int
+      attach_function :max_uncompact_size, :maxUncompactSize, [H3SetIn, :size, Resolution], :int
       attach_function :polyfill, [GeoPolygon.by_ref, Resolution, :output_buffer], :void
-      attach_function :uncompact, [:h3_set, :size, :output_buffer, :size, Resolution], :bool
+      attach_function :uncompact, [H3SetIn, :size, :output_buffer, :size, Resolution], :bool
     end
   end
 end

--- a/lib/h3/bindings/structs.rb
+++ b/lib/h3/bindings/structs.rb
@@ -14,7 +14,7 @@ module H3
 
       class GeoBoundary < FFI::Struct
         layout :num_verts, :int,
-               :verts, [:double, 20] # array of GeoCoord structs (must be fixed length)
+               :verts, [GeoCoord, 10] # array of GeoCoord structs (must be fixed length)
       end
 
       class GeoFence < FFI::Struct

--- a/lib/h3/bindings/types.rb
+++ b/lib/h3/bindings/types.rb
@@ -32,19 +32,39 @@ module H3
         native_type FFI::Type::POINTER
 
         def self.to_native(h3_set_in, _context)
-          pointer = FFI::MemoryPointer.new(:ulong_long, h3_set_in.length)
-          pointer.write_array_of_ulong_long(h3_set_in.set)
-          pointer
+          h3_set_in.ptr
         end
 
-        attr_reader :set
+        attr_reader :set, :ptr
 
         def initialize(set)
           @set = set
+          @ptr = FFI::MemoryPointer.new(:ulong_long, set.size)
+          ptr.write_array_of_ulong_long(set)
         end
 
-        def length
-          @set.length
+        def size
+          @set.size
+        end
+      end
+
+      class H3SetOut
+        extend FFI::DataConverter
+        native_type FFI::Type::POINTER
+
+        def self.to_native(h3_set_out, _context)
+          h3_set_out.ptr
+        end
+
+        attr_reader :size, :ptr
+
+        def initialize(size)
+          @size = size
+          @ptr = FFI::MemoryPointer.new(:ulong_long, size)
+        end
+
+        def read
+          @read ||= ptr.read_array_of_ulong_long(size).reject(&:zero?)
         end
       end
     end

--- a/lib/h3/bindings/types.rb
+++ b/lib/h3/bindings/types.rb
@@ -58,6 +58,18 @@ module H3
           @read ||= ptr.read_array_of_ulong_long(size).reject(&:zero?)
         end
       end
+
+      module H3Set
+        class << self
+          def of_size(size)
+            H3SetOut.new(size)
+          end
+
+          def with_contents(set)
+            H3SetIn.new(set)
+          end
+        end
+      end
     end
   end
 end

--- a/lib/h3/bindings/types.rb
+++ b/lib/h3/bindings/types.rb
@@ -35,32 +35,23 @@ module H3
           h3_set_in.ptr
         end
 
-        attr_reader :set, :ptr
+        attr_reader :ptr, :size
 
         def initialize(set)
-          @set = set
-          @ptr = FFI::MemoryPointer.new(:ulong_long, set.size)
+          @size = set.size   
           ptr.write_array_of_ulong_long(set)
         end
 
-        def size
-          @set.size
+        def ptr
+          @ptr ||= FFI::MemoryPointer.new(:ulong_long, size)
         end
       end
 
-      class H3SetOut
-        extend FFI::DataConverter
+      class H3SetOut < H3SetIn
         native_type FFI::Type::POINTER
-
-        def self.to_native(h3_set_out, _context)
-          h3_set_out.ptr
-        end
-
-        attr_reader :size, :ptr
 
         def initialize(size)
           @size = size
-          @ptr = FFI::MemoryPointer.new(:ulong_long, size)
         end
 
         def read

--- a/lib/h3/bindings/types.rb
+++ b/lib/h3/bindings/types.rb
@@ -38,6 +38,7 @@ module H3
         attr_reader :ptr, :size
 
         def initialize(set)
+          set = set.uniq
           @size = set.size   
           ptr.write_array_of_ulong_long(set)
         end

--- a/lib/h3/bindings/types.rb
+++ b/lib/h3/bindings/types.rb
@@ -27,7 +27,7 @@ module H3
         end
       end
 
-      class H3SetIn
+      class H3IndexesIn
         extend FFI::DataConverter
         native_type FFI::Type::POINTER
 
@@ -38,7 +38,6 @@ module H3
         attr_reader :ptr, :size
 
         def initialize(set)
-          set = set.uniq
           @size = set.size   
           ptr.write_array_of_ulong_long(set)
         end
@@ -48,7 +47,7 @@ module H3
         end
       end
 
-      class H3SetOut < H3SetIn
+      class H3IndexesOut < H3IndexesIn
         native_type FFI::Type::POINTER
 
         def initialize(size)
@@ -60,14 +59,14 @@ module H3
         end
       end
 
-      module H3Set
+      module H3Indexes
         class << self
           def of_size(size)
-            H3SetOut.new(size)
+            H3IndexesOut.new(size)
           end
 
           def with_contents(set)
-            H3SetIn.new(set)
+            H3IndexesIn.new(set)
           end
         end
       end

--- a/lib/h3/bindings/types.rb
+++ b/lib/h3/bindings/types.rb
@@ -26,6 +26,27 @@ module H3
           end
         end
       end
+
+      class H3SetIn
+        extend FFI::DataConverter
+        native_type FFI::Type::POINTER
+
+        def self.to_native(h3_set_in, _context)
+          pointer = FFI::MemoryPointer.new(:ulong_long, h3_set_in.length)
+          pointer.write_array_of_ulong_long(h3_set_in.set)
+          pointer
+        end
+
+        attr_reader :set
+
+        def initialize(set)
+          @set = set
+        end
+
+        def length
+          @set.length
+        end
+      end
     end
   end
 end

--- a/lib/h3/hierarchy.rb
+++ b/lib/h3/hierarchy.rb
@@ -48,7 +48,7 @@ module H3
     # @return [Array<Integer>] H3 indexes of child hexagons.
     def h3_to_children(h3_index, child_resolution)
       max_children = max_h3_to_children_size(h3_index, child_resolution)
-      out = H3SetOut.new(max_children)
+      out = H3Set.of_size(max_children)
       Bindings::Private.h3_to_children(h3_index, child_resolution, out)
       out.read
     end
@@ -73,7 +73,7 @@ module H3
     # @return [Integer] Maximum size of uncompacted set.
     def max_uncompact_size(compacted_set, resolution)
       compacted_set = compacted_set.uniq
-      h3_set = H3SetIn.new(compacted_set)
+      h3_set = H3Set.with_contents(compacted_set)
       size = Bindings::Private.max_uncompact_size(h3_set, compacted_set.size, resolution)
       raise(ArgumentError, "Couldn't estimate size. Invalid resolution?") if size.negative?
       size
@@ -107,8 +107,8 @@ module H3
     def compact(h3_set)
       h3_set = h3_set.uniq
       out_size = h3_set.size
-      h3_set = H3SetIn.new(h3_set)
-      out = H3SetOut.new(out_size)
+      h3_set = H3Set.with_contents(h3_set)
+      out = H3Set.of_size(out_size)
       failure = Bindings::Private.compact(h3_set, out, out_size)
 
       raise "Couldn't compact given indexes" if failure
@@ -143,8 +143,8 @@ module H3
       max_size = max_uncompact_size(compacted_set, resolution)
 
       failure = false
-      out = H3SetOut.new(max_size)
-      h3_set = H3SetIn.new(compacted_set)
+      out = H3Set.of_size(max_size)
+      h3_set = H3Set.with_contents(compacted_set)
       failure = Bindings::Private.uncompact(h3_set, compacted_set.size, out, max_size, resolution)
 
       raise "Couldn't uncompact given indexes" if failure

--- a/lib/h3/hierarchy.rb
+++ b/lib/h3/hierarchy.rb
@@ -48,9 +48,9 @@ module H3
     # @return [Array<Integer>] H3 indexes of child hexagons.
     def h3_to_children(h3_index, child_resolution)
       max_children = max_h3_to_children_size(h3_index, child_resolution)
-      h3_children = FFI::MemoryPointer.new(H3_INDEX, max_children)
-      Bindings::Private.h3_to_children(h3_index, child_resolution, h3_children)
-      h3_children.read_array_of_ulong_long(max_children).reject(&:zero?)
+      out = H3SetOut.new(max_children)
+      Bindings::Private.h3_to_children(h3_index, child_resolution, out)
+      out.read
     end
 
     # Find the maximum uncompacted size of the given set of H3 indexes.
@@ -108,12 +108,11 @@ module H3
       h3_set = h3_set.uniq
       out_size = h3_set.size
       h3_set = H3SetIn.new(h3_set)
-      failure = false
-      out = FFI::MemoryPointer.new(H3_INDEX, out_size)
+      out = H3SetOut.new(out_size)
       failure = Bindings::Private.compact(h3_set, out, out_size)
 
       raise "Couldn't compact given indexes" if failure
-      out.read_array_of_ulong_long(out_size).reject(&:zero?)
+      out.read
     end
 
     # Uncompact a set of H3 indexes to the given resolution.
@@ -144,12 +143,12 @@ module H3
       max_size = max_uncompact_size(compacted_set, resolution)
 
       failure = false
-      out = FFI::MemoryPointer.new(H3_INDEX, max_size)
+      out = H3SetOut.new(max_size)
       h3_set = H3SetIn.new(compacted_set)
       failure = Bindings::Private.uncompact(h3_set, compacted_set.size, out, max_size, resolution)
 
       raise "Couldn't uncompact given indexes" if failure
-      out.read_array_of_ulong_long(max_size).reject(&:zero?)
+      out.read
     end
   end
 end

--- a/lib/h3/hierarchy.rb
+++ b/lib/h3/hierarchy.rb
@@ -72,7 +72,6 @@ module H3
     #
     # @return [Integer] Maximum size of uncompacted set.
     def max_uncompact_size(compacted_set, resolution)
-      compacted_set = compacted_set.uniq
       h3_set = H3Set.with_contents(compacted_set)
       size = Bindings::Private.max_uncompact_size(h3_set, compacted_set.size, resolution)
       raise(ArgumentError, "Couldn't estimate size. Invalid resolution?") if size.negative?
@@ -105,11 +104,9 @@ module H3
     #
     # @return [Array<Integer>] Compacted set of H3 indexes.
     def compact(h3_set)
-      h3_set = h3_set.uniq
-      out_size = h3_set.size
       h3_set = H3Set.with_contents(h3_set)
-      out = H3Set.of_size(out_size)
-      failure = Bindings::Private.compact(h3_set, out, out_size)
+      out = H3Set.of_size(h3_set.size)
+      failure = Bindings::Private.compact(h3_set, out, out.size)
 
       raise "Couldn't compact given indexes" if failure
       out.read

--- a/lib/h3/hierarchy.rb
+++ b/lib/h3/hierarchy.rb
@@ -48,7 +48,7 @@ module H3
     # @return [Array<Integer>] H3 indexes of child hexagons.
     def h3_to_children(h3_index, child_resolution)
       max_children = max_h3_to_children_size(h3_index, child_resolution)
-      out = H3Set.of_size(max_children)
+      out = H3Indexes.of_size(max_children)
       Bindings::Private.h3_to_children(h3_index, child_resolution, out)
       out.read
     end
@@ -72,7 +72,7 @@ module H3
     #
     # @return [Integer] Maximum size of uncompacted set.
     def max_uncompact_size(compacted_set, resolution)
-      h3_set = H3Set.with_contents(compacted_set)
+      h3_set = H3Indexes.with_contents(compacted_set)
       size = Bindings::Private.max_uncompact_size(h3_set, compacted_set.size, resolution)
       raise(ArgumentError, "Couldn't estimate size. Invalid resolution?") if size.negative?
       size
@@ -104,8 +104,8 @@ module H3
     #
     # @return [Array<Integer>] Compacted set of H3 indexes.
     def compact(h3_set)
-      h3_set = H3Set.with_contents(h3_set)
-      out = H3Set.of_size(h3_set.size)
+      h3_set = H3Indexes.with_contents(h3_set)
+      out = H3Indexes.of_size(h3_set.size)
       failure = Bindings::Private.compact(h3_set, out, out.size)
 
       raise "Couldn't compact given indexes" if failure
@@ -140,8 +140,8 @@ module H3
       max_size = max_uncompact_size(compacted_set, resolution)
 
       failure = false
-      out = H3Set.of_size(max_size)
-      h3_set = H3Set.with_contents(compacted_set)
+      out = H3Indexes.of_size(max_size)
+      h3_set = H3Indexes.with_contents(compacted_set)
       failure = Bindings::Private.uncompact(h3_set, compacted_set.size, out, max_size, resolution)
 
       raise "Couldn't uncompact given indexes" if failure

--- a/lib/h3/indexing.rb
+++ b/lib/h3/indexing.rb
@@ -73,9 +73,9 @@ module H3
     def h3_to_geo_boundary(h3_index)
       geo_boundary = GeoBoundary.new
       Bindings::Private.h3_to_geo_boundary(h3_index, geo_boundary)
-      geo_boundary[:verts].take(geo_boundary[:num_verts] * 2).map do |d|
-        rads_to_degs(d)
-      end.each_slice(2).to_a
+      geo_boundary[:verts].take(geo_boundary[:num_verts]).map do |d|
+        [rads_to_degs(d[:lat]), rads_to_degs(d[:lon])]
+      end
     end
   end
 end

--- a/lib/h3/indexing.rb
+++ b/lib/h3/indexing.rb
@@ -7,6 +7,7 @@ module H3
   #
   # @see https://uber.github.io/h3/#/documentation/api-reference/indexing
   module Indexing
+    include Bindings::Structs
     # Derive H3 index for the given set of coordinates.
     #
     # @param [Array<Integer>] coords A coordinate pair.
@@ -28,7 +29,7 @@ module H3
         raise(ArgumentError, "Invalid coordinates")
       end
 
-      coords = Bindings::Structs::GeoCoord.new
+      coords = GeoCoord.new
       coords[:lat] = degs_to_rads(lat)
       coords[:lon] = degs_to_rads(lon)
       Bindings::Private.geo_to_h3(coords, resolution)
@@ -46,7 +47,7 @@ module H3
     #
     # @return [Array<Integer>] A coordinate pair.
     def h3_to_geo(h3_index)
-      coords = Bindings::Structs::GeoCoord.new
+      coords = GeoCoord.new
       Bindings::Private.h3_to_geo(h3_index, coords)
       [rads_to_degs(coords[:lat]), rads_to_degs(coords[:lon])]
     end
@@ -70,7 +71,7 @@ module H3
     #
     # @return [Array<Array<Integer>>] An array of six coordinate pairs.
     def h3_to_geo_boundary(h3_index)
-      geo_boundary = Bindings::Structs::GeoBoundary.new
+      geo_boundary = GeoBoundary.new
       Bindings::Private.h3_to_geo_boundary(h3_index, geo_boundary)
       geo_boundary[:verts].take(geo_boundary[:num_verts] * 2).map do |d|
         rads_to_degs(d)

--- a/lib/h3/inspection.rb
+++ b/lib/h3/inspection.rb
@@ -5,7 +5,7 @@ module H3
   module Inspection
     extend H3::Bindings::Base
 
-    H3_TO_STR_BUF_SIZE = 32
+    H3_TO_STR_BUF_SIZE = 17
     private_constant :H3_TO_STR_BUF_SIZE
 
     # @!method h3_resolution(h3_index)

--- a/lib/h3/miscellaneous.rb
+++ b/lib/h3/miscellaneous.rb
@@ -29,7 +29,7 @@ module H3
     #   59.81085794
     #
     # @return [Float] Length of edge in kilometres
-    attach_function :edge_length_km, :edgeLengthKm, %i[int], :double
+    attach_function :edge_length_km, :edgeLengthKm, [Resolution], :double
 
     # @!method edge_length_m(resolution)
     #
@@ -42,7 +42,7 @@ module H3
     #   3229.482772
     #
     # @return [Float] Length of edge in metres
-    attach_function :edge_length_m, :edgeLengthM, %i[int], :double
+    attach_function :edge_length_m, :edgeLengthM, [Resolution], :double
 
     # @!method hex_area_km2(resolution)
     #
@@ -55,7 +55,7 @@ module H3
     #   252.9033645
     #
     # @return [Float] Average hexagon area in square kilometres.
-    attach_function :hex_area_km2, :hexAreaKm2, %i[int], :double
+    attach_function :hex_area_km2, :hexAreaKm2, [Resolution], :double
 
     # @!method hex_area_m2(resolution)
     #
@@ -68,7 +68,7 @@ module H3
     #   15047.5
     #
     # @return [Float] Average hexagon area in square metres.
-    attach_function :hex_area_m2, :hexAreaM2, %i[int], :double
+    attach_function :hex_area_m2, :hexAreaM2, [Resolution], :double
 
     # @!method num_hexagons(resolution)
     #
@@ -81,7 +81,7 @@ module H3
     #   14117882
     #
     # @return [Integer] Number of unique hexagons
-    attach_function :num_hexagons, :numHexagons, %i[int], :ulong_long
+    attach_function :num_hexagons, :numHexagons, [Resolution], :ulong_long
 
     # @!method rads_to_degs(rads)
     #

--- a/lib/h3/regions.rb
+++ b/lib/h3/regions.rb
@@ -138,11 +138,9 @@ module H3
     # @return [Array<Array<Array<Float>>>] Nested array of coordinates.
     def h3_set_to_linked_geo(h3_indexes)
       h3_indexes = h3_indexes.uniq
+      h3_set = H3SetIn.new(h3_indexes)
       linked_geo_polygon = LinkedGeoPolygon.new
-      FFI::MemoryPointer.new(H3_INDEX, h3_indexes.size) do |hexagons_ptr|
-        hexagons_ptr.write_array_of_ulong_long(h3_indexes)
-        Bindings::Private.h3_set_to_linked_geo(hexagons_ptr, h3_indexes.size, linked_geo_polygon)
-      end
+      Bindings::Private.h3_set_to_linked_geo(h3_set, h3_indexes.size, linked_geo_polygon)
 
       extract_linked_geo_polygon(linked_geo_polygon).first
     end

--- a/lib/h3/regions.rb
+++ b/lib/h3/regions.rb
@@ -137,7 +137,6 @@ module H3
     #
     # @return [Array<Array<Array<Float>>>] Nested array of coordinates.
     def h3_set_to_linked_geo(h3_indexes)
-      h3_indexes = h3_indexes.uniq
       h3_set = H3Set.with_contents(h3_indexes)
       linked_geo_polygon = LinkedGeoPolygon.new
       Bindings::Private.h3_set_to_linked_geo(h3_set, h3_indexes.size, linked_geo_polygon)

--- a/lib/h3/regions.rb
+++ b/lib/h3/regions.rb
@@ -138,7 +138,7 @@ module H3
     # @return [Array<Array<Array<Float>>>] Nested array of coordinates.
     def h3_set_to_linked_geo(h3_indexes)
       h3_indexes = h3_indexes.uniq
-      linked_geo_polygon = Bindings::Structs::LinkedGeoPolygon.new
+      linked_geo_polygon = LinkedGeoPolygon.new
       FFI::MemoryPointer.new(H3_INDEX, h3_indexes.size) do |hexagons_ptr|
         hexagons_ptr.write_array_of_ulong_long(h3_indexes)
         Bindings::Private.h3_set_to_linked_geo(hexagons_ptr, h3_indexes.size, linked_geo_polygon)
@@ -205,14 +205,14 @@ module H3
 
     def build_polygon(input)
       outline, *holes = input
-      geo_polygon = Bindings::Structs::GeoPolygon.new
+      geo_polygon = GeoPolygon.new
       geo_polygon[:geofence] = build_geofence(outline)
       len = holes.count
       geo_polygon[:num_holes] = len
       geofences = holes.map(&method(:build_geofence))
-      ptr = FFI::MemoryPointer.new(Bindings::Structs::GeoFence, len)
+      ptr = FFI::MemoryPointer.new(GeoFence, len)
       fence_structs = 0.upto(geofences.count).map do |i|
-        Bindings::Structs::GeoFence.new(ptr + i * Bindings::Structs::GeoFence.size)
+        GeoFence.new(ptr + i * GeoFence.size)
       end
       geofences.each_with_index do |geofence, i|
         fence_structs[i][:num_verts] = geofence[:num_verts]
@@ -223,12 +223,12 @@ module H3
     end
 
     def build_geofence(input)
-      geo_fence = Bindings::Structs::GeoFence.new
+      geo_fence = GeoFence.new
       len = input.count
       geo_fence[:num_verts] = len
-      ptr = FFI::MemoryPointer.new(Bindings::Structs::GeoCoord, len)
+      ptr = FFI::MemoryPointer.new(GeoCoord, len)
       coords = 0.upto(len).map do |i|
-        Bindings::Structs::GeoCoord.new(ptr + i * Bindings::Structs::GeoCoord.size)
+        GeoCoord.new(ptr + i * GeoCoord.size)
       end
       input.each_with_index do |(lat, lon), i|
         coords[i][:lat] = degs_to_rads(lat)

--- a/lib/h3/regions.rb
+++ b/lib/h3/regions.rb
@@ -105,7 +105,7 @@ module H3
     def polyfill(geo_polygon, resolution)
       geo_polygon = geo_json_to_coordinates(geo_polygon) if geo_polygon.is_a?(String)
       max_size = max_polyfill_size(geo_polygon, resolution)
-      out = H3SetOut.new(max_size)
+      out = H3Set.of_size(max_size)
       Bindings::Private.polyfill(build_polygon(geo_polygon), resolution, out)
       out.read
     end
@@ -138,7 +138,7 @@ module H3
     # @return [Array<Array<Array<Float>>>] Nested array of coordinates.
     def h3_set_to_linked_geo(h3_indexes)
       h3_indexes = h3_indexes.uniq
-      h3_set = H3SetIn.new(h3_indexes)
+      h3_set = H3Set.with_contents(h3_indexes)
       linked_geo_polygon = LinkedGeoPolygon.new
       Bindings::Private.h3_set_to_linked_geo(h3_set, h3_indexes.size, linked_geo_polygon)
 

--- a/lib/h3/regions.rb
+++ b/lib/h3/regions.rb
@@ -105,9 +105,9 @@ module H3
     def polyfill(geo_polygon, resolution)
       geo_polygon = geo_json_to_coordinates(geo_polygon) if geo_polygon.is_a?(String)
       max_size = max_polyfill_size(geo_polygon, resolution)
-      out = FFI::MemoryPointer.new(H3_INDEX, max_size)
+      out = H3SetOut.new(max_size)
       Bindings::Private.polyfill(build_polygon(geo_polygon), resolution, out)
-      out.read_array_of_ulong_long(max_size).reject(&:zero?)
+      out.read
     end
 
     # Derive a nested array of coordinates from a list of H3 indexes.

--- a/lib/h3/regions.rb
+++ b/lib/h3/regions.rb
@@ -105,7 +105,7 @@ module H3
     def polyfill(geo_polygon, resolution)
       geo_polygon = geo_json_to_coordinates(geo_polygon) if geo_polygon.is_a?(String)
       max_size = max_polyfill_size(geo_polygon, resolution)
-      out = H3Set.of_size(max_size)
+      out = H3Indexes.of_size(max_size)
       Bindings::Private.polyfill(build_polygon(geo_polygon), resolution, out)
       out.read
     end
@@ -137,7 +137,7 @@ module H3
     #
     # @return [Array<Array<Array<Float>>>] Nested array of coordinates.
     def h3_set_to_linked_geo(h3_indexes)
-      h3_set = H3Set.with_contents(h3_indexes)
+      h3_set = H3Indexes.with_contents(h3_indexes)
       linked_geo_polygon = LinkedGeoPolygon.new
       Bindings::Private.h3_set_to_linked_geo(h3_set, h3_indexes.size, linked_geo_polygon)
 

--- a/lib/h3/traversal.rb
+++ b/lib/h3/traversal.rb
@@ -81,7 +81,7 @@ module H3
     # @return [Array<Integer>] Array of H3 indexes within the k-range.
     def hex_range(origin, k)
       max_hexagons = max_kring_size(k)
-      out = H3Set.of_size(max_hexagons)
+      out = H3Indexes.of_size(max_hexagons)
       pentagonal_distortion = Bindings::Private.hex_range(origin, k, out)
       raise(ArgumentError, "Specified hexagon range contains a pentagon") if pentagonal_distortion
       out.read
@@ -110,7 +110,7 @@ module H3
     # @return [Array<Integer>] Array of H3 indexes within the k-range.
     def k_ring(origin, k)
       max_hexagons = max_kring_size(k)
-      out = H3Set.of_size(max_hexagons)
+      out = H3Indexes.of_size(max_hexagons)
       Bindings::Private.k_ring(origin, k, out)
       out.read
     end
@@ -135,7 +135,7 @@ module H3
     # @return [Array<Integer>] Array of H3 indexes within the hex ring.
     def hex_ring(origin, k)
       max_hexagons = max_hex_ring_size(k)
-      out = H3Set.of_size(max_hexagons)
+      out = H3Indexes.of_size(max_hexagons)
       pentagonal_distortion = Bindings::Private.hex_ring(origin, k, out)
       raise(ArgumentError, "The hex ring contains a pentagon") if pentagonal_distortion
       out.read
@@ -232,7 +232,7 @@ module H3
     # @return [Hash] Hex range grouped by distance.
     def hex_range_distances(origin, k)
       max_out_size = max_kring_size(k)
-      out = H3Set.of_size(max_out_size)
+      out = H3Indexes.of_size(max_out_size)
       distances = FFI::MemoryPointer.new(:int, max_out_size)
       pentagonal_distortion = Bindings::Private.hex_range_distances(origin, k, out, distances)
       raise(ArgumentError, "Specified hexagon range contains a pentagon") if pentagonal_distortion
@@ -269,7 +269,7 @@ module H3
     # @return [Hash] Hash of k-ring distances grouped by distance.
     def k_ring_distances(origin, k)
       max_out_size = max_kring_size(k)
-      out = H3Set.of_size(max_out_size)
+      out = H3Indexes.of_size(max_out_size)
       distances = FFI::MemoryPointer.new(:int, max_out_size)
       Bindings::Private.k_ring_distances(origin, k, out, distances)
 
@@ -299,7 +299,7 @@ module H3
     # @return [Array<Integer>] H3 indexes
     def h3_line(origin, destination)
       max_hexagons = h3_line_size(origin, destination)
-      hexagons = H3Set.of_size(max_hexagons)
+      hexagons = H3Indexes.of_size(max_hexagons)
       res = Bindings::Private.h3_line(origin, destination, hexagons)
       raise(ArgumentError, "Could not compute line") if res.negative?
       hexagons.read
@@ -316,9 +316,9 @@ module H3
     end
 
     def hex_ranges_ungrouped(h3_set, k)
-      h3_set = H3Set.with_contents(h3_set)
+      h3_set = H3Indexes.with_contents(h3_set)
       max_out_size = h3_set.size * max_kring_size(k)
-      out = H3Set.of_size(max_out_size)
+      out = H3Indexes.of_size(max_out_size)
       if Bindings::Private.hex_ranges(h3_set, h3_set.size, k, out)
         raise(ArgumentError, "One of the specified hexagon ranges contains a pentagon")
       end

--- a/lib/h3/traversal.rb
+++ b/lib/h3/traversal.rb
@@ -317,14 +317,10 @@ module H3
 
     def hex_ranges_ungrouped(h3_set, k)
       h3_set = h3_set.uniq
+      h3_set_in = H3SetIn.new(h3_set)
       max_out_size = h3_set.size * max_kring_size(k)
       out = FFI::MemoryPointer.new(H3_INDEX, max_out_size)
-      pentagonal_distortion = false
-      FFI::MemoryPointer.new(H3_INDEX, h3_set.size) do |h3_set_ptr|
-        h3_set_ptr.write_array_of_ulong_long(h3_set)
-        pentagonal_distortion = Bindings::Private.hex_ranges(h3_set_ptr, h3_set.size, k, out)
-      end
-      if pentagonal_distortion
+      if Bindings::Private.hex_ranges(h3_set_in, h3_set.size, k, out)
         raise(ArgumentError, "One of the specified hexagon ranges contains a pentagon")
       end
 

--- a/lib/h3/traversal.rb
+++ b/lib/h3/traversal.rb
@@ -316,11 +316,10 @@ module H3
     end
 
     def hex_ranges_ungrouped(h3_set, k)
-      h3_set = h3_set.uniq
-      h3_set_in = H3Set.with_contents(h3_set)
+      h3_set = H3Set.with_contents(h3_set)
       max_out_size = h3_set.size * max_kring_size(k)
       out = H3Set.of_size(max_out_size)
-      if Bindings::Private.hex_ranges(h3_set_in, h3_set.size, k, out)
+      if Bindings::Private.hex_ranges(h3_set, h3_set.size, k, out)
         raise(ArgumentError, "One of the specified hexagon ranges contains a pentagon")
       end
 

--- a/lib/h3/traversal.rb
+++ b/lib/h3/traversal.rb
@@ -81,10 +81,10 @@ module H3
     # @return [Array<Integer>] Array of H3 indexes within the k-range.
     def hex_range(origin, k)
       max_hexagons = max_kring_size(k)
-      hexagons = FFI::MemoryPointer.new(:ulong_long, max_hexagons)
-      pentagonal_distortion = Bindings::Private.hex_range(origin, k, hexagons)
+      out = H3SetOut.new(max_hexagons)
+      pentagonal_distortion = Bindings::Private.hex_range(origin, k, out)
       raise(ArgumentError, "Specified hexagon range contains a pentagon") if pentagonal_distortion
-      hexagons.read_array_of_ulong_long(max_hexagons).reject(&:zero?)
+      out.read
     end
 
     # Derives H3 indexes within k distance of the origin H3 index.
@@ -110,9 +110,9 @@ module H3
     # @return [Array<Integer>] Array of H3 indexes within the k-range.
     def k_ring(origin, k)
       max_hexagons = max_kring_size(k)
-      hexagons = FFI::MemoryPointer.new(:ulong_long, max_hexagons)
-      Bindings::Private.k_ring(origin, k, hexagons)
-      hexagons.read_array_of_ulong_long(max_hexagons).reject(&:zero?)
+      out = H3SetOut.new(max_hexagons)
+      Bindings::Private.k_ring(origin, k, out)
+      out.read
     end
 
     # Derives the hollow hexagonal ring centered at origin with sides of length k.
@@ -135,10 +135,10 @@ module H3
     # @return [Array<Integer>] Array of H3 indexes within the hex ring.
     def hex_ring(origin, k)
       max_hexagons = max_hex_ring_size(k)
-      hexagons = FFI::MemoryPointer.new(:ulong_long, max_hexagons)
-      pentagonal_distortion = Bindings::Private.hex_ring(origin, k, hexagons)
+      out = H3SetOut.new(max_hexagons)
+      pentagonal_distortion = Bindings::Private.hex_ring(origin, k, out)
       raise(ArgumentError, "The hex ring contains a pentagon") if pentagonal_distortion
-      hexagons.read_array_of_ulong_long(max_hexagons).reject(&:zero?)
+      out.read
     end
 
     # Derive the maximum hex ring size for a given distance k.
@@ -232,12 +232,12 @@ module H3
     # @return [Hash] Hex range grouped by distance.
     def hex_range_distances(origin, k)
       max_out_size = max_kring_size(k)
-      out = FFI::MemoryPointer.new(H3_INDEX, max_out_size)
+      out = H3SetOut.new(max_out_size)
       distances = FFI::MemoryPointer.new(:int, max_out_size)
       pentagonal_distortion = Bindings::Private.hex_range_distances(origin, k, out, distances)
       raise(ArgumentError, "Specified hexagon range contains a pentagon") if pentagonal_distortion
 
-      hexagons = out.read_array_of_ulong_long(max_out_size)
+      hexagons = out.read
       distances = distances.read_array_of_int(max_out_size)
 
       Hash[
@@ -269,11 +269,11 @@ module H3
     # @return [Hash] Hash of k-ring distances grouped by distance.
     def k_ring_distances(origin, k)
       max_out_size = max_kring_size(k)
-      out = FFI::MemoryPointer.new(H3_INDEX, max_out_size)
+      out = H3SetOut.new(max_out_size)
       distances = FFI::MemoryPointer.new(:int, max_out_size)
       Bindings::Private.k_ring_distances(origin, k, out, distances)
 
-      hexagons = out.read_array_of_ulong_long(max_out_size)
+      hexagons = out.read
       distances = distances.read_array_of_int(max_out_size)
 
       Hash[
@@ -299,10 +299,10 @@ module H3
     # @return [Array<Integer>] H3 indexes
     def h3_line(origin, destination)
       max_hexagons = h3_line_size(origin, destination)
-      hexagons = FFI::MemoryPointer.new(:ulong_long, max_hexagons)
+      hexagons = H3Set.of_size(max_hexagons)
       res = Bindings::Private.h3_line(origin, destination, hexagons)
       raise(ArgumentError, "Could not compute line") if res.negative?
-      hexagons.read_array_of_ulong_long(max_hexagons).reject(&:zero?)
+      hexagons.read
     end
 
     private
@@ -319,12 +319,12 @@ module H3
       h3_set = h3_set.uniq
       h3_set_in = H3SetIn.new(h3_set)
       max_out_size = h3_set.size * max_kring_size(k)
-      out = FFI::MemoryPointer.new(H3_INDEX, max_out_size)
+      out = H3SetOut.new(max_out_size)
       if Bindings::Private.hex_ranges(h3_set_in, h3_set.size, k, out)
         raise(ArgumentError, "One of the specified hexagon ranges contains a pentagon")
       end
 
-      out.read_array_of_ulong_long(max_out_size)
+      out.read
     end
   end
 end

--- a/lib/h3/traversal.rb
+++ b/lib/h3/traversal.rb
@@ -81,7 +81,7 @@ module H3
     # @return [Array<Integer>] Array of H3 indexes within the k-range.
     def hex_range(origin, k)
       max_hexagons = max_kring_size(k)
-      out = H3SetOut.new(max_hexagons)
+      out = H3Set.of_size(max_hexagons)
       pentagonal_distortion = Bindings::Private.hex_range(origin, k, out)
       raise(ArgumentError, "Specified hexagon range contains a pentagon") if pentagonal_distortion
       out.read
@@ -110,7 +110,7 @@ module H3
     # @return [Array<Integer>] Array of H3 indexes within the k-range.
     def k_ring(origin, k)
       max_hexagons = max_kring_size(k)
-      out = H3SetOut.new(max_hexagons)
+      out = H3Set.of_size(max_hexagons)
       Bindings::Private.k_ring(origin, k, out)
       out.read
     end
@@ -135,7 +135,7 @@ module H3
     # @return [Array<Integer>] Array of H3 indexes within the hex ring.
     def hex_ring(origin, k)
       max_hexagons = max_hex_ring_size(k)
-      out = H3SetOut.new(max_hexagons)
+      out = H3Set.of_size(max_hexagons)
       pentagonal_distortion = Bindings::Private.hex_ring(origin, k, out)
       raise(ArgumentError, "The hex ring contains a pentagon") if pentagonal_distortion
       out.read
@@ -232,7 +232,7 @@ module H3
     # @return [Hash] Hex range grouped by distance.
     def hex_range_distances(origin, k)
       max_out_size = max_kring_size(k)
-      out = H3SetOut.new(max_out_size)
+      out = H3Set.of_size(max_out_size)
       distances = FFI::MemoryPointer.new(:int, max_out_size)
       pentagonal_distortion = Bindings::Private.hex_range_distances(origin, k, out, distances)
       raise(ArgumentError, "Specified hexagon range contains a pentagon") if pentagonal_distortion
@@ -269,7 +269,7 @@ module H3
     # @return [Hash] Hash of k-ring distances grouped by distance.
     def k_ring_distances(origin, k)
       max_out_size = max_kring_size(k)
-      out = H3SetOut.new(max_out_size)
+      out = H3Set.of_size(max_out_size)
       distances = FFI::MemoryPointer.new(:int, max_out_size)
       Bindings::Private.k_ring_distances(origin, k, out, distances)
 
@@ -317,9 +317,9 @@ module H3
 
     def hex_ranges_ungrouped(h3_set, k)
       h3_set = h3_set.uniq
-      h3_set_in = H3SetIn.new(h3_set)
+      h3_set_in = H3Set.with_contents(h3_set)
       max_out_size = h3_set.size * max_kring_size(k)
-      out = H3SetOut.new(max_out_size)
+      out = H3Set.of_size(max_out_size)
       if Bindings::Private.hex_ranges(h3_set_in, h3_set.size, k, out)
         raise(ArgumentError, "One of the specified hexagon ranges contains a pentagon")
       end

--- a/lib/h3/unidirectional_edges.rb
+++ b/lib/h3/unidirectional_edges.rb
@@ -99,7 +99,7 @@ module H3
     # @return [Array<Integer>] H3 index array.
     def h3_indexes_from_unidirectional_edge(edge)
       max_hexagons = 2
-      out = H3Set.of_size(max_hexagons)
+      out = H3Indexes.of_size(max_hexagons)
       Bindings::Private.h3_indexes_from_unidirectional_edge(edge, out)
       out.read
     end
@@ -118,7 +118,7 @@ module H3
     # @return [Array<Integer>] H3 index array.
     def h3_unidirectional_edges_from_hexagon(origin)
       max_edges = 6
-      out = H3Set.of_size(max_edges)
+      out = H3Indexes.of_size(max_edges)
       Bindings::Private.h3_unidirectional_edges_from_hexagon(origin, out)
       out.read
     end

--- a/lib/h3/unidirectional_edges.rb
+++ b/lib/h3/unidirectional_edges.rb
@@ -139,9 +139,9 @@ module H3
     def h3_unidirectional_edge_boundary(edge)
       geo_boundary = GeoBoundary.new
       Bindings::Private.h3_unidirectional_edge_boundary(edge, geo_boundary)
-      geo_boundary[:verts].take(geo_boundary[:num_verts] * 2).map do |d|
-        rads_to_degs(d)
-      end.each_slice(2).to_a
+      geo_boundary[:verts].take(geo_boundary[:num_verts]).map do |d|
+        [rads_to_degs(d[:lat]), rads_to_degs(d[:lon])]
+      end
     end
   end
 end

--- a/lib/h3/unidirectional_edges.rb
+++ b/lib/h3/unidirectional_edges.rb
@@ -99,9 +99,9 @@ module H3
     # @return [Array<Integer>] H3 index array.
     def h3_indexes_from_unidirectional_edge(edge)
       max_hexagons = 2
-      origin_destination = FFI::MemoryPointer.new(:ulong_long, max_hexagons)
-      Bindings::Private.h3_indexes_from_unidirectional_edge(edge, origin_destination)
-      origin_destination.read_array_of_ulong_long(max_hexagons).reject(&:zero?)
+      out = H3SetOut.new(max_hexagons)
+      Bindings::Private.h3_indexes_from_unidirectional_edge(edge, out)
+      out.read
     end
 
     # Derive unidirectional edges for a H3 index.
@@ -119,8 +119,9 @@ module H3
     def h3_unidirectional_edges_from_hexagon(origin)
       max_edges = 6
       edges = FFI::MemoryPointer.new(:ulong_long, max_edges)
-      Bindings::Private.h3_unidirectional_edges_from_hexagon(origin, edges)
-      edges.read_array_of_ulong_long(max_edges).reject(&:zero?)
+      out = H3SetOut.new(max_edges)
+      Bindings::Private.h3_unidirectional_edges_from_hexagon(origin, out)
+      out.read
     end
 
     # Derive coordinates for edge boundary.

--- a/lib/h3/unidirectional_edges.rb
+++ b/lib/h3/unidirectional_edges.rb
@@ -99,7 +99,7 @@ module H3
     # @return [Array<Integer>] H3 index array.
     def h3_indexes_from_unidirectional_edge(edge)
       max_hexagons = 2
-      out = H3SetOut.new(max_hexagons)
+      out = H3Set.of_size(max_hexagons)
       Bindings::Private.h3_indexes_from_unidirectional_edge(edge, out)
       out.read
     end
@@ -118,8 +118,7 @@ module H3
     # @return [Array<Integer>] H3 index array.
     def h3_unidirectional_edges_from_hexagon(origin)
       max_edges = 6
-      edges = FFI::MemoryPointer.new(:ulong_long, max_edges)
-      out = H3SetOut.new(max_edges)
+      out = H3Set.of_size(max_edges)
       Bindings::Private.h3_unidirectional_edges_from_hexagon(origin, out)
       out.read
     end

--- a/lib/h3/unidirectional_edges.rb
+++ b/lib/h3/unidirectional_edges.rb
@@ -137,7 +137,7 @@ module H3
     #
     # @return [Array<Array<Float>>] Edge boundary coordinates for a hexagon
     def h3_unidirectional_edge_boundary(edge)
-      geo_boundary = Bindings::Structs::GeoBoundary.new
+      geo_boundary = GeoBoundary.new
       Bindings::Private.h3_unidirectional_edge_boundary(edge, geo_boundary)
       geo_boundary[:verts].take(geo_boundary[:num_verts] * 2).map do |d|
         rads_to_degs(d)

--- a/spec/miscellaneous_spec.rb
+++ b/spec/miscellaneous_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe H3 do
       let(:result) { false }
 
       it "returns the expected result" do
-        expect { num_hexagons }.to raise_error(RangeError)
+        expect { num_hexagons }.to raise_error(ArgumentError)
       end
     end
   end


### PR DESCRIPTION
- [x] Don't refer to classes with a full namespace when they're already mixed in.
- [x] Set up `GeoBoundary` size correctly by referring to `GeoCoord`.
- [x] Move Memory Pointer code for H3 Sets into FFI types.