### PR TITLE
Deprecate longwinded method names

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,15 @@ Please consult [the H3 documentation](https://uber.github.io/h3/#/documentation/
 
 ## Supported H3 Versions
 
-The semantic versioning of this gem matches the versioning of the H3 C library. E.g. version `3.2.x` of this gem is targeted for version `3.2.y` of H3 C lib where `x` and `y` are independent patch levels.
+The semantic versioning of this gem matches the versioning of the H3 C library. E.g. version `3.5.x` of this gem is targeted for version `3.5.y` of H3 C lib where `x` and `y` are independent patch levels.
 
 ## Naming Conventions
 
 We have changed camel-case method names to snake-case, as per the Ruby convention.
 
-In addition, some methods using the `get` verb have been renamed i.e. `getH3UnidirectionalEdgesFromHexagon` becomes `h3_unidirectional_edges_from_hexagon`.
+In addition, some methods using the `get` verb have been renamed i.e. `getH3UnidirectionalEdgesFromHexagon` becomes `unidirectional_edges_from_hexagon`.
 
-We have also suffixed predicate methods with a question mark, as per the Ruby convention, and removed `is` from the name i.e. `h3IsPentagon` becomes `h3_pentagon?`
+We have also suffixed predicate methods with a question mark, as per the Ruby convention, and removed `h3Is` from the name i.e. `h3IsPentagon` becomes `pentagon?`
 
 ## Getting Started
 
@@ -53,13 +53,13 @@ require "h3"
 Call H3 functions via the `H3` namespace
 
 ```ruby
-H3.geo_to_h3([53.959130, -1.079230], 8).to_s(16)
+H3.from_geo_coordinates([53.959130, -1.079230], 8).to_s(16)
 => "8819429a9dfffff"
-H3.h3_valid?("8819429a9dfffff".to_i(16))
+H3.valid?("8819429a9dfffff".to_i(16))
 => true
-H3.h3_pentagon?("8819429a9dfffff".to_i(16))
+H3.pentagon?("8819429a9dfffff".to_i(16))
 => false
-H3.h3_to_geo_boundary("8819429a9dfffff".to_i(16))
+H3.to_boundary("8819429a9dfffff".to_i(16))
 => [[53.962987505331384, -1.079984346847996], [53.9618315234061, -1.0870313428985856], [53.95744798515881, -1.0882421079017874], [53.95422067486053, -1.082406760751464], [53.955376670617454, -1.0753609232787642], [53.95975996282198, -1.074149274503605]]
 ```
 

--- a/lib/h3.rb
+++ b/lib/h3.rb
@@ -19,20 +19,6 @@ module H3
   extend Traversal
   extend UnidirectionalEdges
 
-  PREDICATES = %i[h3_indexes_neighbors h3_pentagon h3_res_class_3
-                  h3_unidirectional_edge_valid h3_valid].freeze
-  private_constant :PREDICATES
-
-  class << self
-    # FFI's attach_function doesn't allow method names ending with a
-    # question mark. This works around the issue by dynamically
-    # renaming those methods afterwards.
-    PREDICATES.each do |predicate|
-      alias_method "#{predicate}?", predicate
-      undef_method predicate
-    end
-  end
-
   # Internal bindings related modules and classes.
   #
   # These are intended to be used by the library's public methods

--- a/lib/h3/bindings/base.rb
+++ b/lib/h3/bindings/base.rb
@@ -7,6 +7,7 @@ module H3
       def self.extended(base)
         lib_path = File.expand_path(__dir__ + "/../../../ext/h3/src/lib")
         base.extend FFI::Library
+        base.extend Gem::Deprecate
         base.include Structs
         base.include Types
         base.ffi_lib ["#{lib_path}/libh3.dylib", "#{lib_path}/libh3.so"]

--- a/lib/h3/hierarchy.rb
+++ b/lib/h3/hierarchy.rb
@@ -59,7 +59,7 @@ module H3
     #
     # @return [Array<Integer>] H3 indexes of child hexagons.
     def children(h3_index, child_resolution)
-      max_children = max_h3_to_children_size(h3_index, child_resolution)
+      max_children = max_children(h3_index, child_resolution)
       out = H3Indexes.of_size(max_children)
       Bindings::Private.h3_to_children(h3_index, child_resolution, out)
       out.read

--- a/lib/h3/hierarchy.rb
+++ b/lib/h3/hierarchy.rb
@@ -5,7 +5,7 @@ module H3
   module Hierarchy
     extend H3::Bindings::Base
 
-    # @!method h3_to_parent(h3_index, parent_resolution)
+    # @!method parent(h3_index, parent_resolution)
     #
     # Derive the parent hexagon which contains the hexagon at the given H3 index.
     #
@@ -13,13 +13,19 @@ module H3
     # @param [Integer] parent_resoluton The desired resolution of the parent hexagon.
     #
     # @example Find the parent hexagon for a H3 index.
-    #   H3.h3_to_parent(613196570357137407, 6)
+    #   H3.parent(613196570357137407, 6)
     #   604189371209351167
     #
     # @return [Integer] H3 index of parent hexagon.
-    attach_function :h3_to_parent, :h3ToParent, [:h3_index, Resolution], :h3_index
+    attach_function :parent, :h3ToParent, [:h3_index, Resolution], :h3_index
 
-    # @!method max_h3_to_children_size(h3_index, child_resolution)
+    # @deprecated Please use {#parent} instead.
+    def h3_to_parent(h3_index, resolution)
+      parent(h3_index, resolution)
+    end
+    deprecate :h3_to_parent, :parent, 2020, 1
+
+    # @!method max_children(h3_index, child_resolution)
     #
     # Derive maximum number of child hexagons possible at given resolution.
     #
@@ -27,11 +33,17 @@ module H3
     # @param [Integer] child_resoluton The desired resolution of the child hexagons.
     #
     # @example Derive maximum number of child hexagons.
-    #    H3.max_h3_to_children_size(613196570357137407, 10)
+    #    H3.max_children(613196570357137407, 10)
     #    49
     #
     # @return [Integer] Maximum number of child hexagons possible at given resolution.
-    attach_function :max_h3_to_children_size, :maxH3ToChildrenSize, [:h3_index, Resolution], :int
+    attach_function :max_children, :maxH3ToChildrenSize, [:h3_index, Resolution], :int
+
+    # @deprecated Please use {#max_children} instead.
+    def max_h3_to_children_size(h3_index, resolution)
+      max_children(h3_index, resolution)
+    end
+    deprecate :max_h3_to_children_size, :max_children, 2020, 1
 
     # Derive child hexagons contained within the hexagon at the given H3 index.
     #
@@ -39,19 +51,25 @@ module H3
     # @param [Integer] child_resolution The desired resolution of hexagons returned.
     #
     # @example Find the child hexagons for a H3 index.
-    #   H3.h3_to_children(613196570357137407, 9)
+    #   H3.children(613196570357137407, 9)
     #   [
     #     617700169982672895, 617700169982935039, 617700169983197183, 617700169983459327,
     #     617700169983721471, 617700169983983615, 617700169984245759
     #   ]
     #
     # @return [Array<Integer>] H3 indexes of child hexagons.
-    def h3_to_children(h3_index, child_resolution)
+    def children(h3_index, child_resolution)
       max_children = max_h3_to_children_size(h3_index, child_resolution)
       out = H3Indexes.of_size(max_children)
       Bindings::Private.h3_to_children(h3_index, child_resolution, out)
       out.read
     end
+
+    # @deprecated Please use {#children} instead.
+    def h3_to_children(h3_index, resolution)
+      children(h3_index, resolution)
+    end
+    deprecate :h3_to_children, :children, 2020, 1
 
     # Find the maximum uncompacted size of the given set of H3 indexes.
     #

--- a/lib/h3/indexing.rb
+++ b/lib/h3/indexing.rb
@@ -8,19 +8,20 @@ module H3
   # @see https://uber.github.io/h3/#/documentation/api-reference/indexing
   module Indexing
     include Bindings::Structs
+    extend Gem::Deprecate
     # Derive H3 index for the given set of coordinates.
     #
     # @param [Array<Integer>] coords A coordinate pair.
     # @param [Integer] resolution The desired resolution of the H3 index.
     #
     # @example Derive the H3 index for the given coordinates.
-    #   H3.geo_to_h3([52.24630137198303, -1.7358398437499998], 9)
+    #   H3.from_geo([52.24630137198303, -1.7358398437499998], 9)
     #   617439284584775679
     #
     # @raise [ArgumentError] If coordinates are invalid.
     #
     # @return [Integer] H3 index.
-    def geo_to_h3(coords, resolution)
+    def from_geo(coords, resolution)
       raise ArgumentError unless coords.is_a?(Array) && coords.count == 2
 
       lat, lon = coords
@@ -35,6 +36,12 @@ module H3
       Bindings::Private.geo_to_h3(coords, resolution)
     end
 
+    # @deprecated Please use {#from_geo} instead.
+    def geo_to_h3(coords, resolution)
+      from_geo(coords, resolution)
+    end
+    deprecate :geo_to_h3, :from_geo, 2020, 1
+
     # Derive coordinates for a given H3 index.
     #
     # The coordinates map to the centre of the hexagon at the given index.
@@ -42,15 +49,21 @@ module H3
     # @param [Integer] h3_index A valid H3 index.
     #
     # @example Derive the central coordinates for the given H3 index.
-    #   H3.h3_to_geo(617439284584775679)
+    #   H3.to_geo(617439284584775679)
     #   [52.245519061399506, -1.7363137757391423]
     #
     # @return [Array<Integer>] A coordinate pair.
-    def h3_to_geo(h3_index)
+    def to_geo(h3_index)
       coords = GeoCoord.new
       Bindings::Private.h3_to_geo(h3_index, coords)
       [rads_to_degs(coords[:lat]), rads_to_degs(coords[:lon])]
     end
+
+    # @deprecated Please use {#to_geo_coordinates} instead.
+    def h3_to_geo(h3_index)
+      to_geo(h3_index)
+    end
+    deprecate :h3_to_geo, :to_geo, 2020, 1
 
     # Derive the geographical boundary as coordinates for a given H3 index.
     #
@@ -62,7 +75,7 @@ module H3
     # @param [Integer] h3_index A valid H3 index.
     #
     # @example Derive the geographical boundary for the given H3 index.
-    #   H3.h3_to_geo_boundary(617439284584775679)
+    #   H3.to_geo_boundary(617439284584775679)
     #   [
     #     [52.247260929171055, -1.736809158397472], [52.24625850761068, -1.7389279144996015],
     #     [52.244516619273476, -1.7384324668792375], [52.243777169245725, -1.7358184256304658],
@@ -70,12 +83,18 @@ module H3
     #   ]
     #
     # @return [Array<Array<Integer>>] An array of six coordinate pairs.
-    def h3_to_geo_boundary(h3_index)
+    def to_geo_boundary(h3_index)
       geo_boundary = GeoBoundary.new
       Bindings::Private.h3_to_geo_boundary(h3_index, geo_boundary)
       geo_boundary[:verts].take(geo_boundary[:num_verts]).map do |d|
         [rads_to_degs(d[:lat]), rads_to_degs(d[:lon])]
       end
     end
+
+    # @deprecated Please use {#to_geo_boundary} instead.
+    def h3_to_geo_boundary(h3_index)
+      to_geo_boundary(h3_index)
+    end
+    deprecate :h3_to_geo_boundary, :to_geo_boundary, 2020, 1
   end
 end

--- a/lib/h3/indexing.rb
+++ b/lib/h3/indexing.rb
@@ -7,21 +7,20 @@ module H3
   #
   # @see https://uber.github.io/h3/#/documentation/api-reference/indexing
   module Indexing
-    include Bindings::Structs
-    extend Gem::Deprecate
+    extend H3::Bindings::Base
     # Derive H3 index for the given set of coordinates.
     #
     # @param [Array<Integer>] coords A coordinate pair.
     # @param [Integer] resolution The desired resolution of the H3 index.
     #
     # @example Derive the H3 index for the given coordinates.
-    #   H3.from_geo([52.24630137198303, -1.7358398437499998], 9)
+    #   H3.from_geo_coordinates([52.24630137198303, -1.7358398437499998], 9)
     #   617439284584775679
     #
     # @raise [ArgumentError] If coordinates are invalid.
     #
     # @return [Integer] H3 index.
-    def from_geo(coords, resolution)
+    def from_geo_coordinates(coords, resolution)
       raise ArgumentError unless coords.is_a?(Array) && coords.count == 2
 
       lat, lon = coords
@@ -36,11 +35,11 @@ module H3
       Bindings::Private.geo_to_h3(coords, resolution)
     end
 
-    # @deprecated Please use {#from_geo} instead.
+    # @deprecated Please use {#from_geo_coordinates} instead.
     def geo_to_h3(coords, resolution)
-      from_geo(coords, resolution)
+      from_geo_coordinates(coords, resolution)
     end
-    deprecate :geo_to_h3, :from_geo, 2020, 1
+    deprecate :geo_to_h3, :from_geo_coordinates, 2020, 1
 
     # Derive coordinates for a given H3 index.
     #
@@ -49,11 +48,11 @@ module H3
     # @param [Integer] h3_index A valid H3 index.
     #
     # @example Derive the central coordinates for the given H3 index.
-    #   H3.to_geo(617439284584775679)
+    #   H3.to_geo_coordinates(617439284584775679)
     #   [52.245519061399506, -1.7363137757391423]
     #
     # @return [Array<Integer>] A coordinate pair.
-    def to_geo(h3_index)
+    def to_geo_coordinates(h3_index)
       coords = GeoCoord.new
       Bindings::Private.h3_to_geo(h3_index, coords)
       [rads_to_degs(coords[:lat]), rads_to_degs(coords[:lon])]
@@ -61,9 +60,9 @@ module H3
 
     # @deprecated Please use {#to_geo_coordinates} instead.
     def h3_to_geo(h3_index)
-      to_geo(h3_index)
+      to_geo_coordinates(h3_index)
     end
-    deprecate :h3_to_geo, :to_geo, 2020, 1
+    deprecate :h3_to_geo, :to_geo_coordinates, 2020, 1
 
     # Derive the geographical boundary as coordinates for a given H3 index.
     #
@@ -75,7 +74,7 @@ module H3
     # @param [Integer] h3_index A valid H3 index.
     #
     # @example Derive the geographical boundary for the given H3 index.
-    #   H3.to_geo_boundary(617439284584775679)
+    #   H3.to_boundary(617439284584775679)
     #   [
     #     [52.247260929171055, -1.736809158397472], [52.24625850761068, -1.7389279144996015],
     #     [52.244516619273476, -1.7384324668792375], [52.243777169245725, -1.7358184256304658],
@@ -83,7 +82,7 @@ module H3
     #   ]
     #
     # @return [Array<Array<Integer>>] An array of six coordinate pairs.
-    def to_geo_boundary(h3_index)
+    def to_boundary(h3_index)
       geo_boundary = GeoBoundary.new
       Bindings::Private.h3_to_geo_boundary(h3_index, geo_boundary)
       geo_boundary[:verts].take(geo_boundary[:num_verts]).map do |d|
@@ -91,10 +90,10 @@ module H3
       end
     end
 
-    # @deprecated Please use {#to_geo_boundary} instead.
+    # @deprecated Please use {#to_boundary} instead.
     def h3_to_geo_boundary(h3_index)
-      to_geo_boundary(h3_index)
+      to_boundary(h3_index)
     end
-    deprecate :h3_to_geo_boundary, :to_geo_boundary, 2020, 1
+    deprecate :h3_to_geo_boundary, :to_boundary, 2020, 1
   end
 end

--- a/lib/h3/inspection.rb
+++ b/lib/h3/inspection.rb
@@ -8,59 +8,85 @@ module H3
     H3_TO_STR_BUF_SIZE = 17
     private_constant :H3_TO_STR_BUF_SIZE
 
-    # @!method h3_resolution(h3_index)
+    # @!method resolution(h3_index)
     #
     # Derive the resolution of a given H3 index
     #
     # @param [Integer] h3_index A valid H3 index
     #
     # @example Derive the resolution of a H3 index
-    #   H3.h3_resolution(617700440100569087)
+    #   H3.resolution(617700440100569087)
     #   9
     #
     # @return [Integer] Resolution of H3 index
-    attach_function :h3_resolution, :h3GetResolution, %i[h3_index], Resolution
+    attach_function :resolution, :h3GetResolution, %i[h3_index], Resolution
 
-    # @!method h3_base_cell(h3_index)
+    # @deprecated Please use {#resolution} instead.
+    def h3_resolution(h3_index)
+      resolution(h3_index)
+    end
+    deprecate :h3_resolution, :resolution, 2020, 1
+
+    # @!method base_cell(h3_index)
     #
     # Derives the base cell number of the given H3 index
     #
     # @param [Integer] h3_index A valid H3 index
     #
     # @example Derive the base cell number of a H3 index
-    #   H3.h3_base_cell(617700440100569087)
+    #   H3.base_cell(617700440100569087)
     #   20
     #
     # @return [Integer] Base cell number
-    attach_function :h3_base_cell, :h3GetBaseCell, %i[h3_index], :int
+    attach_function :base_cell, :h3GetBaseCell, %i[h3_index], :int
 
-    # @!method string_to_h3(h3_string)
+    # @deprecated Please use {#base_cell} instead.
+    def h3_base_cell(h3_index)
+      base_cell(h3_index)
+    end
+    deprecate :h3_base_cell, :base_cell, 2020, 1
+
+    # @!method from_string(h3_string)
     #
     # Derives the H3 index for a given hexadecimal string representation.
     #
     # @param [String] h3_string A H3 index in hexadecimal form.
     #
     # @example Derive the H3 index from the given hexadecimal form.
-    #   H3.string_to_h3("8928308280fffff")
+    #   H3.from_string("8928308280fffff")
     #   617700169958293503
     #
     # @return [Integer] H3 index
-    attach_function :string_to_h3, :stringToH3, %i[string], :h3_index
+    attach_function :from_string, :stringToH3, %i[string], :h3_index
 
-    # @!method h3_pentagon?(h3_index)
+    # @deprecated Please use {#from_string} instead.
+    def string_to_h3(string)
+      from_string(string)
+    end
+    deprecate :string_to_h3, :from_string, 2020, 1
+
+    # @!method pentagon?(h3_index)
     #
     # Determine whether the given H3 index is a pentagon.
     #
     # @param [Integer] h3_index A valid H3 index.
     #
     # @example Check if H3 index is a pentagon
-    #   H3.h3_pentagon?(585961082523222015)
+    #   H3.pentagon?(585961082523222015)
     #   true
     #
     # @return [Boolean] True if the H3 index is a pentagon.
-    attach_function :h3_pentagon, :h3IsPentagon, %i[h3_index], :bool
+    attach_function :pentagon, :h3IsPentagon, %i[h3_index], :bool
+    alias_method :pentagon?, :pentagon
+    undef_method :pentagon
 
-    # @!method h3_res_class_3?(h3_index)
+    # @deprecated Please use {#pentagon?} instead.
+    def h3_pentagon?(h3_index)
+      pentagon?(h3_index)
+    end
+    deprecate :h3_pentagon?, :pentagon?, 2020, 1
+
+    # @!method class_3_resolution?(h3_index)
     #
     # Determine whether the given H3 index has a resolution with
     # Class III orientation.
@@ -68,39 +94,61 @@ module H3
     # @param [Integer] h3_index A valid H3 index.
     #
     # @example Check if H3 index has a class III resolution.
-    #   H3.h3_res_class_3?(599686042433355775)
+    #   H3.class_3_resolution?(599686042433355775)
     #   true
     #
     # @return [Boolean] True if the H3 index has a class III resolution.
-    attach_function :h3_res_class_3, :h3IsResClassIII, %i[h3_index], :bool
+    attach_function :class_3_resolution, :h3IsResClassIII, %i[h3_index], :bool
+    alias_method :class_3_resolution?, :class_3_resolution
+    undef_method :class_3_resolution
 
-    # @!method h3_valid?(h3_index)
+    # @deprecated Please use {#class_3_resolution?} instead.
+    def h3_res_class_3?(h3_index)
+      class_3_resolution?(h3_index)
+    end
+    deprecate :h3_res_class_3?, :class_3_resolution?, 2020, 1
+
+    # @!method valid?(h3_index)
     #
     # Determine whether the given H3 index is valid.
     #
     # @param [Integer] h3_index A H3 index.
     #
     # @example Check if H3 index is valid
-    #   H3.h3_valid?(599686042433355775)
+    #   H3.valid?(599686042433355775)
     #   true
     #
     # @return [Boolean] True if the H3 index is valid.
-    attach_function :h3_valid, :h3IsValid, %i[h3_index], :bool
+    attach_function :valid, :h3IsValid, %i[h3_index], :bool
+    alias_method :valid?, :valid
+    undef_method :valid
+
+    # @deprecated Please use {#valid?} instead.
+    def h3_valid?(h3_index)
+      valid?(h3_index)
+    end
+    deprecate :h3_valid?, :valid?, 2020, 1
 
     # Derives the hexadecimal string representation for a given H3 index.
     #
     # @param [Integer] h3_index A valid H3 index.
     #
     # @example Derive the given hexadecimal form for the H3 index
-    #   H3.h3_to_string(617700169958293503)
+    #   H3.to_string(617700169958293503)
     #   "89283470dcbffff"
     #
     # @return [String] H3 index in hexadecimal form.
-    def h3_to_string(h3_index)
+    def to_string(h3_index)
       h3_str = FFI::MemoryPointer.new(:char, H3_TO_STR_BUF_SIZE)
       Bindings::Private.h3_to_string(h3_index, h3_str, H3_TO_STR_BUF_SIZE)
       h3_str.read_string
     end
+
+    # @deprecated Please use {#to_string} instead.
+    def h3_to_string(h3_index)
+      to_string(h3_index)
+    end
+    deprecate :h3_to_string, :to_strings, 2020, 1
 
     # @!method max_face_count(h3_index)
     #
@@ -115,25 +163,29 @@ module H3
     # @return [Integer] Maximum possible number of faces
     attach_function :max_face_count, :maxFaceCount, %i[h3_index], :int
 
-    # void h3GetFaces(H3Index h, int* out);
-
-    # @!method h3_faces(h3_index)
+    # @!method faces(h3_index)
     #
     # Find all icosahedron faces intersected by a given H3 index.
     #
     # @param [Integer] h3_index A H3 index.
     #
     # @example Find icosahedron faces for given index
-    #   H3.h3_faces(585961082523222015)
+    #   H3.faces(585961082523222015)
     #   [1, 2, 6, 7, 11]
     #
     # @return [Array<Integer>] Faces. Faces are represented as integers from 0-19, inclusive.
-    def h3_faces(h3_index)
+    def faces(h3_index)
       max_faces = max_face_count(h3_index)
       out = FFI::MemoryPointer.new(:int, max_faces)
       Bindings::Private.h3_faces(h3_index, out)
       # The C function returns a sparse array whose holes are represented by -1.
       out.read_array_of_int(max_faces).reject(&:negative?).sort
     end
+
+    # @deprecated Please use {#faces} instead.
+    def h3_faces(h3_index)
+      faces(h3_index)
+    end
+    deprecate :h3_faces, :faces, 2020, 1
   end
 end

--- a/lib/h3/miscellaneous.rb
+++ b/lib/h3/miscellaneous.rb
@@ -70,18 +70,24 @@ module H3
     # @return [Float] Average hexagon area in square metres.
     attach_function :hex_area_m2, :hexAreaM2, [Resolution], :double
 
-    # @!method num_hexagons(resolution)
+    # @!method hexagon_count(resolution)
     #
     # Number of unique H3 indexes at the given resolution.
     #
     # @param [Integer] resolution Resolution.
     #
     # @example Find number of hexagons at resolution 6
-    #   H3.num_hexagons(6)
+    #   H3.hexagon_count(6)
     #   14117882
     #
     # @return [Integer] Number of unique hexagons
-    attach_function :num_hexagons, :numHexagons, [Resolution], :ulong_long
+    attach_function :hexagon_count, :numHexagons, [Resolution], :ulong_long
+
+    # @deprecated Please use {#hexagon_count} instead.
+    def num_hexagons(resolution)
+      hexagon_count(resolution)
+    end
+    deprecate :num_hexagons, :hexagon_count, 2020, 1
 
     # @!method rads_to_degs(rads)
     #
@@ -96,28 +102,40 @@ module H3
     # @return [Float] Value expressed in degrees.
     attach_function :rads_to_degs, :radsToDegs, %i[double], :double
 
-    # @!method res_0_index_count
+    # @!method base_cell_count
     #
     # Returns the number of resolution 0 hexagons (base cells).
     #
     # @example Return the number of base cells
-    #    H3.res_0_index_count
+    #    H3.base_cell_count
     #    122
     #
     # @return [Integer] The number of resolution 0 hexagons (base cells).
-    attach_function :res_0_index_count, :res0IndexCount, [], :int
+    attach_function :base_cell_count, :res0IndexCount, [], :int
+
+    # @deprecated Please use {#base_cell_count} instead.
+    def res_0_index_count
+      base_cell_count
+    end
+    deprecate :res_0_index_count, :base_cell_count, 2020, 1
 
     # Returns all resolution 0 hexagons (base cells).
     #
     # @example Return all base cells.
-    #   H3.res_0_indexes
+    #   H3.base_cells
     #   [576495936675512319, 576531121047601151, ..., 580753245698260991]
     #
     # @return [Array<Integer>] All resolution 0 hexagons (base cells).
-    def res_0_indexes
+    def base_cells
       out = H3Indexes.of_size(res_0_index_count)
       Bindings::Private.res_0_indexes(out)
       out.read
     end
+
+    # @deprecated Please use {#base_cells} instead.
+    def res_0_indexes
+      base_cells
+    end
+    deprecate :res_0_indexes, :base_cells, 2020, 1
   end
 end

--- a/lib/h3/miscellaneous.rb
+++ b/lib/h3/miscellaneous.rb
@@ -127,7 +127,7 @@ module H3
     #
     # @return [Array<Integer>] All resolution 0 hexagons (base cells).
     def base_cells
-      out = H3Indexes.of_size(res_0_index_count)
+      out = H3Indexes.of_size(base_cell_count)
       Bindings::Private.res_0_indexes(out)
       out.read
     end

--- a/lib/h3/traversal.rb
+++ b/lib/h3/traversal.rb
@@ -18,7 +18,7 @@ module H3
     # @return [Integer] Maximum k-ring size.
     attach_function :max_kring_size, :maxKringSize, %i[k_distance], :int
 
-    # @!method h3_distance(origin, h3_index)
+    # @!method distance(origin, h3_index)
     #
     # Derive the distance between two H3 indexes.
     #
@@ -26,13 +26,19 @@ module H3
     # @param [Integer] h3_index H3 index
     #
     # @example Derive the distance between two H3 indexes.
-    #   H3.h3_distance(617700169983721471, 617700169959866367)
+    #   H3.distance(617700169983721471, 617700169959866367)
     #   5
     #
     # @return [Integer] Distance between indexes.
-    attach_function :h3_distance, :h3Distance, %i[h3_index h3_index], :k_distance
+    attach_function :distance, :h3Distance, %i[h3_index h3_index], :k_distance
 
-    # @!method h3_line_size(origin, destination)
+    # @deprecated Please use {#distance} instead.
+    def h3_distance(origin, destination)
+      distance(origin, destination)
+    end
+    deprecate :h3_distance, :distance, 2020, 1
+
+    # @!method line_size(origin, destination)
     #
     # Derive the number of hexagons present in a line between two H3 indexes.
     #
@@ -45,11 +51,17 @@ module H3
     # @param [Integer] destination H3 index
     #
     # @example Derive the number of hexagons present in a line between two H3 indexes.
-    #   H3.h3_line_size(617700169983721471, 617700169959866367)
+    #   H3.line_size(617700169983721471, 617700169959866367)
     #   6
     #
     # @return [Integer] Number of hexagons found between indexes.
-    attach_function :h3_line_size, :h3LineSize, %i[h3_index h3_index], :int
+    attach_function :line_size, :h3LineSize, %i[h3_index h3_index], :int
+
+    # @deprecated Please use {#line_size} instead.
+    def h3_line_size(origin, destination)
+      line_size(origin, destination)
+    end
+    deprecate :h3_line_size, :line_size, 2020, 1
 
     # Derives H3 indexes within k distance of the origin H3 index.
     #

--- a/lib/h3/traversal.rb
+++ b/lib/h3/traversal.rb
@@ -300,7 +300,7 @@ module H3
     # @param [Integer] destination Destination H3 index.
     #
     # @example Derive the indexes found in a line.
-    #   H3.h3_line(617700169983721471, 617700169959866367)
+    #   H3.line(617700169983721471, 617700169959866367)
     #   [
     #     617700169983721471, 617700169984245759, 617700169988177919,
     #     617700169986867199, 617700169987391487, 617700169959866367
@@ -309,13 +309,19 @@ module H3
     # @raise [ArgumentError] Could not compute line
     #
     # @return [Array<Integer>] H3 indexes
-    def h3_line(origin, destination)
-      max_hexagons = h3_line_size(origin, destination)
+    def line(origin, destination)
+      max_hexagons = line_size(origin, destination)
       hexagons = H3Indexes.of_size(max_hexagons)
       res = Bindings::Private.h3_line(origin, destination, hexagons)
       raise(ArgumentError, "Could not compute line") if res.negative?
       hexagons.read
     end
+
+    # @deprecated Please use {#line} instead.
+    def h3_line(origin, destination)
+      line(origin, destination)
+    end
+    deprecate :h3_line, :line, 2020, 1
 
     private
 

--- a/lib/h3/unidirectional_edges.rb
+++ b/lib/h3/unidirectional_edges.rb
@@ -5,7 +5,7 @@ module H3
   module UnidirectionalEdges
     extend H3::Bindings::Base
 
-    # @!method h3_indexes_neighbors?(origin, destination)
+    # @!method neighbors?(origin, destination)
     #
     # Determine whether two H3 indexes are neighbors.
     #
@@ -13,29 +13,47 @@ module H3
     # @param [Integer] destination Destination H3 index
     #
     # @example Check two H3 indexes
-    #   H3.h3_indexes_neighbors?(617700169958293503, 617700169958031359)
+    #   H3.neighbors?(617700169958293503, 617700169958031359)
     #   true
     #
     # @return [Boolean] True if indexes are neighbors
-    attach_function :h3_indexes_neighbors, :h3IndexesAreNeighbors, %i[h3_index h3_index], :bool
+    attach_function :neighbors, :h3IndexesAreNeighbors, %i[h3_index h3_index], :bool
+    alias_method :neighbors?, :neighbors
+    undef_method :neighbors
 
-    # @!method h3_unidirectional_edge_valid?(h3_index)
+    # @deprecated Please use {#neighbors?} instead.
+    def h3_indexes_neighbors?(origin, destination)
+      neighbors?(origin, destination)
+    end
+
+    deprecate :h3_indexes_neighbors?, :neighbors?, 2020, 1
+
+    # @!method unidirectional_edge_valid?(h3_index)
     #
     # Determine whether the given H3 index represents an edge.
     #
     # @param [Integer] h3_index H3 index
     #
     # @example Check if H3 index is a valid unidirectional edge.
-    #   H3.h3_unidirectional_edge_valid?(1266218516299644927)
+    #   H3.unidirectional_edge_valid?(1266218516299644927)
     #   true
     #
     # @return [Boolean] True if H3 index is a valid unidirectional edge
-    attach_function :h3_unidirectional_edge_valid,
+    attach_function :unidirectional_edge_valid,
                     :h3UnidirectionalEdgeIsValid,
                     %i[h3_index],
                     :bool
+    alias_method :unidirectional_edge_valid?, :unidirectional_edge_valid
+    undef_method :unidirectional_edge_valid
 
-    # @!method h3_unidirectional_edge(origin, destination)
+    # @deprecated Please use {#unidirectional_edge_valid?} instead.
+    def h3_unidirectional_edge_valid?(h3_index)
+      unidirectional_edge_valid?(h3_index)
+    end
+
+    deprecate :h3_unidirectional_edge_valid?, :unidirectional_edge_valid?, 2020, 1
+
+    # @!method unidirectional_edge(origin, destination)
     #
     # Derives the H3 index of the edge from the given H3 indexes.
     #
@@ -43,14 +61,21 @@ module H3
     # @param [Integer] destination H3 index
     #
     # @example Derive the H3 edge index between two H3 indexes
-    #   H3.h3_unidirectional_edge(617700169958293503, 617700169958031359)
+    #   H3.unidirectional_edge(617700169958293503, 617700169958031359)
     #   1626506486489284607
     #
     # @return [Integer] H3 edge index
-    attach_function :h3_unidirectional_edge,
+    attach_function :unidirectional_edge,
                     :getH3UnidirectionalEdge,
                     %i[h3_index h3_index],
                     :h3_index
+
+    # @deprecated Please use {#unidirectional_edge} instead.
+    def h3_unidirectional_edge(origin, destination)
+      unidirectional_edge(origin, destination)
+    end
+
+    deprecate :h3_unidirectional_edge, :unidirectional_edge, 2020, 1
 
     # @!method destination_from_unidirectional_edge(edge)
     #
@@ -93,42 +118,62 @@ module H3
     # @param [Integer] edge H3 edge index
     #
     # @example Get origin and destination indexes from edge
-    #   H3.h3_indexes_from_unidirectional_edge(1266218516299644927)
+    #   H3.origin_and_destination_from_unidirectional_edge(1266218516299644927)
     #   [617700169958293503, 617700169961177087]
     #
     # @return [Array<Integer>] H3 index array.
-    def h3_indexes_from_unidirectional_edge(edge)
+    def origin_and_destination_from_unidirectional_edge(edge)
       max_hexagons = 2
       out = H3Indexes.of_size(max_hexagons)
       Bindings::Private.h3_indexes_from_unidirectional_edge(edge, out)
       out.read
     end
 
+    # @deprecated Please use {#origin_and_destination_from_unidirectional_edge} instead.
+    def h3_indexes_from_unidirectional_edge(edge)
+      origin_and_destination_from_unidirectional_edge(edge)
+    end
+
+    deprecate :h3_indexes_from_unidirectional_edge,
+              :origin_and_destination_from_unidirectional_edge,
+              2020,
+              1
+
     # Derive unidirectional edges for a H3 index.
     #
     # @param [Integer] origin H3 index
     #
     # @example Get unidirectional indexes from hexagon
-    #   H3.h3_unidirectional_edges_from_hexagon(612933930963697663)
+    #   H3.unidirectional_edges_from_hexagon(612933930963697663)
     #   [
     #     1261452277305049087, 1333509871342977023, 1405567465380904959,
     #     1477625059418832895, 1549682653456760831, 1621740247494688767
     #   ]
     #
     # @return [Array<Integer>] H3 index array.
-    def h3_unidirectional_edges_from_hexagon(origin)
+    def unidirectional_edges_from_hexagon(origin)
       max_edges = 6
       out = H3Indexes.of_size(max_edges)
       Bindings::Private.h3_unidirectional_edges_from_hexagon(origin, out)
       out.read
     end
 
+    # @deprecated Please use {#unidirectional_edges_from_hexagon} instead.
+    def h3_unidirectional_edges_from_hexagon(origin)
+      unidirectional_edges_from_hexagon(origin)
+    end
+
+    deprecate :h3_unidirectional_edges_from_hexagon,
+              :unidirectional_edges_from_hexagon,
+              2020,
+              1
+
     # Derive coordinates for edge boundary.
     #
     # @param [Integer] edge H3 edge index
     #
     # @example
-    #   H3.h3_unidirectional_edge_boundary(612933930963697663)
+    #   H3.unidirectional_edge_boundary(612933930963697663)
     #   [
     #     [68.92995788193981, 31.831280499087402], [69.39359648991828, 62.345344956509784],
     #     [76.163042830191, 94.14309010184775], [87.36469532319619, 145.5581976913368],
@@ -136,12 +181,22 @@ module H3
     #   ]
     #
     # @return [Array<Array<Float>>] Edge boundary coordinates for a hexagon
-    def h3_unidirectional_edge_boundary(edge)
+    def unidirectional_edge_boundary(edge)
       geo_boundary = GeoBoundary.new
       Bindings::Private.h3_unidirectional_edge_boundary(edge, geo_boundary)
       geo_boundary[:verts].take(geo_boundary[:num_verts]).map do |d|
         [rads_to_degs(d[:lat]), rads_to_degs(d[:lon])]
       end
     end
+
+    # @deprecated Please use {#unidirectional_edge_boundary} instead.
+    def h3_unidirectional_edge_boundary(edge)
+      unidirectional_edge_boundary(edge)
+    end
+
+    deprecate :h3_unidirectional_edge_boundary,
+              :unidirectional_edge_boundary,
+              2020,
+              1
   end
 end

--- a/spec/hierarchy_spec.rb
+++ b/spec/hierarchy_spec.rb
@@ -1,27 +1,27 @@
 RSpec.describe H3 do
   include_context "constants"
 
-  describe ".h3_to_parent" do
+  describe ".parent" do
     let(:h3_index) { "89283082993ffff".to_i(16) }
     let(:parent_resolution) { 8 }
     let(:result) { "8828308299fffff".to_i(16) }
 
-    subject(:h3_to_parent) { H3.h3_to_parent(h3_index, parent_resolution) }
+    subject(:parent) { H3.parent(h3_index, parent_resolution) }
 
     it { is_expected.to eq(result) }
   end
 
-  describe ".h3_to_children" do
+  describe ".children" do
     let(:h3_index) { "8928308280fffff".to_i(16) }
 
-    subject(:h3_to_children) { H3.h3_to_children(h3_index, child_resolution) }
+    subject(:children) { H3.children(h3_index, child_resolution) }
 
     context "when resolution is 3" do
       let(:child_resolution) { 3 }
       let(:count) { 0 }
 
       it "has 0 children" do
-        expect(h3_to_children.count).to eq count
+        expect(children.count).to eq count
       end
     end
 
@@ -31,11 +31,11 @@ RSpec.describe H3 do
       let(:expected) { "8928308280fffff".to_i(16) }
 
       it "has 1 child" do
-        expect(h3_to_children.count).to eq count
+        expect(children.count).to eq count
       end
 
       it "is the expected value" do
-        expect(h3_to_children.first).to eq expected
+        expect(children.first).to eq expected
       end
     end
 
@@ -44,7 +44,7 @@ RSpec.describe H3 do
       let(:count) { 7 }
 
       it "has 7 children" do
-        expect(h3_to_children.count).to eq count
+        expect(children.count).to eq count
       end
     end
 
@@ -53,7 +53,7 @@ RSpec.describe H3 do
       let(:count) { 117649 }
 
       it "has 117649 children" do
-        expect(h3_to_children.count).to eq count
+        expect(children.count).to eq count
       end
     end
 
@@ -61,7 +61,7 @@ RSpec.describe H3 do
       let(:child_resolution) { -1 }
 
       it "raises an error" do
-        expect { h3_to_children }.to raise_error(ArgumentError)
+        expect { children }.to raise_error(ArgumentError)
       end
     end
 
@@ -69,15 +69,15 @@ RSpec.describe H3 do
       let(:child_resolution) { 16 }
 
       it "raises an error" do
-        expect { h3_to_children }.to raise_error(ArgumentError)
+        expect { children }.to raise_error(ArgumentError)
       end
     end
   end
 
-  describe ".max_h3_to_children_size" do
+  describe ".max_children" do
     let(:h3_index) { "8928308280fffff".to_i(16) }
 
-    subject(:h3_to_children) { H3.max_h3_to_children_size(h3_index, child_resolution) }
+    subject(:max_children) { H3.max_children(h3_index, child_resolution) }
 
     context "when resolution is 3" do
       let(:child_resolution) { 3 }

--- a/spec/indexing_spec.rb
+++ b/spec/indexing_spec.rb
@@ -1,12 +1,12 @@
 RSpec.describe H3 do
   include_context "constants"
 
-  describe ".geo_to_h3" do
+  describe ".from_geo_coordinates" do
     let(:resolution) { 8 }
     let(:coords) { [53.959130, -1.079230]}
     let(:result) { valid_h3_index }
 
-    subject(:geo_to_h3) { H3.geo_to_h3(coords, resolution) }
+    subject(:from_geo_coordinates) { H3.from_geo_coordinates(coords, resolution) }
 
     it { is_expected.to eq(result) }
 
@@ -14,7 +14,7 @@ RSpec.describe H3 do
       let(:coords) { [1, 2, 3] }
 
       it "raises an error" do
-        expect { geo_to_h3 }.to raise_error(ArgumentError)
+        expect { from_geo_coordinates }.to raise_error(ArgumentError)
       end
     end
 
@@ -22,7 +22,7 @@ RSpec.describe H3 do
       let(:coords) { "boom" }
 
       it "raises an error" do
-        expect { geo_to_h3 }.to raise_error(ArgumentError)
+        expect { from_geo_coordinates }.to raise_error(ArgumentError)
       end
     end
 
@@ -30,31 +30,31 @@ RSpec.describe H3 do
       let(:coords) { [-1.1323222, 190.1020102] }
 
       it "raises an error" do
-        expect { geo_to_h3 }.to raise_error(ArgumentError)
+        expect { from_geo_coordinates }.to raise_error(ArgumentError)
       end
     end    
   end
 
-  describe ".h3_to_geo" do
+  describe ".to_geo_coordinates" do
     let(:h3_index) { valid_h3_index }
     let(:expected_lat) { 53.95860421941 }
     let(:expected_lon) { -1.08119564709 }
 
-    subject(:h3_to_geo) { H3.h3_to_geo(h3_index) }
+    subject(:to_geo_coordinates) { H3.to_geo_coordinates(h3_index) }
 
     it "should return the expected latitude" do
-      expect(h3_to_geo[0]).to be_within(0.000001).of(expected_lat)
+      expect(to_geo_coordinates[0]).to be_within(0.000001).of(expected_lat)
     end
 
     it "should return the expected longitude" do
-      expect(h3_to_geo[1]).to be_within(0.000001).of(expected_lon)
+      expect(to_geo_coordinates[1]).to be_within(0.000001).of(expected_lon)
     end
 
     context "when given an invalid h3_index" do
       let(:h3_index) { "boom" }
 
       it "raises an error" do
-        expect { h3_to_geo }.to raise_error(TypeError)
+        expect { to_geo_coordinates }.to raise_error(TypeError)
       end
     end
 
@@ -62,12 +62,12 @@ RSpec.describe H3 do
       let(:h3_index) { too_long_number }
 
       it "raises an error" do
-        expect { h3_to_geo }.to raise_error(RangeError)
+        expect { to_geo_coordinates }.to raise_error(RangeError)
       end
     end
   end
 
-  describe ".h3_to_geo_boundary" do
+  describe ".to_boundary" do
     let(:h3_index) { "85283473fffffff".to_i(16) }
     let(:expected) do
       [
@@ -80,10 +80,10 @@ RSpec.describe H3 do
       ]
     end
 
-    subject(:h3_to_geo_boundary) { H3.h3_to_geo_boundary(h3_index) }
+    subject(:to_boundary) { H3.to_boundary(h3_index) }
 
     it "matches expected boundary coordinates" do
-      h3_to_geo_boundary.zip(expected) do |(lat, lon), (exp_lat, exp_lon)|
+      to_boundary.zip(expected) do |(lat, lon), (exp_lat, exp_lon)|
         expect(lat).to be_within(0.000001).of(exp_lat)
         expect(lon).to be_within(0.000001).of(exp_lon)
       end

--- a/spec/inspection_spec.rb
+++ b/spec/inspection_spec.rb
@@ -1,47 +1,47 @@
 RSpec.describe H3 do
   include_context "constants"
 
-  describe ".h3_resolution" do
+  describe ".resolution" do
     let(:h3_index) { valid_h3_index }
     let(:result) { 8 }
 
-    subject(:h3_resolution) { H3.h3_resolution(h3_index) }
+    subject(:resolution) { H3.resolution(h3_index) }
 
     it { is_expected.to eq(result) }
   end
 
-  describe ".h3_base_cell" do
+  describe ".base_cell" do
     let(:h3_index) { valid_h3_index }
     let(:result) { 12 }
 
-    subject(:h3_base_cell) { H3.h3_base_cell(h3_index) }
+    subject(:base_cell) { H3.base_cell(h3_index) }
 
     it { is_expected.to eq(result) }
   end
 
-  describe ".string_to_h3" do
+  describe ".from_string" do
     let(:h3_index) { "8928308280fffff"}
     let(:result) { h3_index.to_i(16) }
 
-    subject(:string_to_h3) { H3.string_to_h3(h3_index) }
+    subject(:from_string) { H3.from_string(h3_index) }
 
     it { is_expected.to eq(result) }
   end
 
-  describe ".h3_to_string" do
+  describe ".to_string" do
     let(:h3_index) { "8928308280fffff".to_i(16) }
     let(:result) { h3_index.to_s(16) }
 
-    subject(:h3_to_string) { H3.h3_to_string(h3_index) }
+    subject(:to_string) { H3.to_string(h3_index) }
 
     it { is_expected.to eq(result) }
   end
 
-  describe ".h3_valid?" do
+  describe ".valid?" do
     let(:h3_index) { valid_h3_index }
     let(:result) { true }
 
-    subject(:h3_valid?) { H3.h3_valid?(h3_index) }
+    subject(:valid?) { H3.valid?(h3_index) }
 
     it { is_expected.to eq(result) }
 
@@ -51,16 +51,16 @@ RSpec.describe H3 do
       let(:result) { false }
 
       it "returns the expected result" do
-        expect(h3_valid?).to eq(result)
+        expect(valid?).to eq(result)
       end
     end
   end
 
-  describe ".h3_res_class_3?" do
+  describe ".class_3_resolution?" do
     let(:h3_index) { "8928308280fffff".to_i(16) }
     let(:result) { true }
 
-    subject(:h3_res_class_3) { H3.h3_res_class_3?(h3_index) }
+    subject(:class_3_resolution) { H3.class_3_resolution?(h3_index) }
 
     it { is_expected.to eq(result) }
 
@@ -72,11 +72,11 @@ RSpec.describe H3 do
     end
   end
 
-  describe ".h3_pentagon?" do
+  describe ".pentagon?" do
     let(:h3_index) { "821c07fffffffff".to_i(16) }
     let(:result) { true }
 
-    subject(:h3_pentagon?) { H3.h3_pentagon?(h3_index) }
+    subject(:pentagon?) { H3.pentagon?(h3_index) }
 
     it { is_expected.to eq(result) }
 
@@ -104,11 +104,11 @@ RSpec.describe H3 do
     end
   end
 
-  describe ".h3_faces" do
+  describe ".faces" do
     let(:h3_index) { "8928308280fffff".to_i(16) }
     let(:result) { [7] }
 
-    subject(:max_face_count) { H3.h3_faces(h3_index) }
+    subject(:faces) { H3.faces(h3_index) }
 
     it { is_expected.to eq(result) }
 

--- a/spec/miscellaneous_spec.rb
+++ b/spec/miscellaneous_spec.rb
@@ -1,11 +1,11 @@
 RSpec.describe H3 do
   include_context "constants"
 
-  describe ".num_hexagons" do
+  describe ".hexagon_count" do
     let(:resolution) { 2 }
     let(:result) { 5882 }
 
-    subject(:num_hexagons) { H3.num_hexagons(resolution) }
+    subject(:hexagon_count) { H3.hexagon_count(resolution) }
 
     it { is_expected.to eq(result) }
 
@@ -14,7 +14,7 @@ RSpec.describe H3 do
       let(:result) { false }
 
       it "returns the expected result" do
-        expect { num_hexagons }.to raise_error(ArgumentError)
+        expect { hexagon_count }.to raise_error(ArgumentError)
       end
     end
   end
@@ -73,12 +73,12 @@ RSpec.describe H3 do
     it { is_expected.to eq(result) }
   end
 
-  describe ".res_0_indexes" do
+  describe ".base_cells" do
     let(:count) { 122 }
-    subject(:res_0_indexes) { H3.res_0_indexes }
+    subject(:base_cells) { H3.base_cells }
 
     it "has 122 base cells" do
-      expect(res_0_indexes.count).to eq(count)
+      expect(base_cells.count).to eq(count)
     end
   end
 end

--- a/spec/traversal_spec.rb
+++ b/spec/traversal_spec.rb
@@ -331,27 +331,27 @@ RSpec.describe H3 do
     end
   end
 
-  describe ".h3_distance" do
+  describe ".distance" do
     let(:origin) { "89283082993ffff".to_i(16) }
     let(:destination) { "89283082827ffff".to_i(16) }
     let(:result) { 5 }
 
-    subject(:h3_distance) { H3.h3_distance(origin, destination) }
+    subject(:distance) { H3.distance(origin, destination) }
 
     it { is_expected.to eq(result) }
   end
 
-  describe ".h3_line_size" do
+  describe ".line_size" do
     let(:origin) { "89283082993ffff".to_i(16) }
     let(:destination) { "89283082827ffff".to_i(16) }
     let(:result) { 6 }
 
-    subject(:h3_line_size) { H3.h3_line_size(origin, destination) }
+    subject(:h3_line_size) { H3.line_size(origin, destination) }
 
     it { is_expected.to eq(result) }
   end
 
-  describe ".h3_line" do
+  describe ".line" do
     let(:origin) { "89283082993ffff".to_i(16) }
     let(:destination) { "89283082827ffff".to_i(16) }
     let(:result) do
@@ -361,7 +361,7 @@ RSpec.describe H3 do
       ].map { |i| i.to_i(16) }
     end
 
-    subject(:h3_line) { H3.h3_line(origin, destination) }
+    subject(:line) { H3.line(origin, destination) }
 
     it { is_expected.to eq(result) }
   end

--- a/spec/unidirectional_edges_spec.rb
+++ b/spec/unidirectional_edges_spec.rb
@@ -1,12 +1,12 @@
 RSpec.describe H3 do
   include_context "constants"
 
-  describe ".h3_indexes_neighbors?" do
+  describe ".neighbors?" do
     let(:origin) { "8928308280fffff".to_i(16) }
     let(:destination) { "8928308280bffff".to_i(16) }
     let(:result) { true }
 
-    subject(:h3_indexes_neighbors?) { H3.h3_indexes_neighbors?(origin, destination) }
+    subject(:neighbors?) { H3.neighbors?(origin, destination) }
 
     it { is_expected.to eq(result) }
 
@@ -18,21 +18,21 @@ RSpec.describe H3 do
     end
   end
 
-  describe ".h3_unidirectional_edge" do
+  describe ".unidirectional_edge" do
     let(:origin) { "8928308280fffff".to_i(16) }
     let(:destination) { "8928308280bffff".to_i(16) }
     let(:result) { "16928308280fffff".to_i(16) }
 
-    subject(:h3_unidirectional_edge) { H3.h3_unidirectional_edge(origin, destination) }
+    subject(:unidirectional_edge) { H3.unidirectional_edge(origin, destination) }
 
     it { is_expected.to eq(result) }
   end
 
-  describe ".h3_unidirectional_edge_valid?" do
+  describe ".unidirectional_edge_valid?" do
     let(:edge) { "11928308280fffff".to_i(16) }
     let(:result) { true }
 
-    subject(:h3_unidirectional_edge_valid?) { H3.h3_unidirectional_edge_valid?(edge) }
+    subject(:h3_unidirectional_edge_valid?) { H3.unidirectional_edge_valid?(edge) }
 
     it { is_expected.to eq(result) }
 
@@ -62,24 +62,24 @@ RSpec.describe H3 do
     it { is_expected.to eq(result) }
   end
 
-  describe ".h3_indexes_from_unidirectional_edge" do
+  describe ".origin_and_destination_from_unidirectional_edge" do
     let(:h3_index) { "11928308280fffff".to_i(16) }
     let(:expected_indexes) do
       %w(8928308280fffff 8928308283bffff).map { |i| i.to_i(16) }
     end
 
-    subject(:h3_indexes_from_unidirectional_edge) do
-      H3.h3_indexes_from_unidirectional_edge(h3_index)
+    subject(:origin_and_destination_from_unidirectional_edge) do
+      H3.origin_and_destination_from_unidirectional_edge(h3_index)
     end
 
     it "has two expected h3 indexes" do
-      expect(h3_indexes_from_unidirectional_edge).to eq(expected_indexes)
+      expect(origin_and_destination_from_unidirectional_edge).to eq(expected_indexes)
     end
   end
 
-  describe ".h3_unidirectional_edges_from_hexagon" do
-    subject(:h3_unidirectional_edges_from_hexagon) do
-      H3.h3_unidirectional_edges_from_hexagon(h3_index)
+  describe ".unidirectional_edges_from_hexagon" do
+    subject(:unidirectional_edges_from_hexagon) do
+      H3.unidirectional_edges_from_hexagon(h3_index)
     end
 
     context "when index is a hexagon" do
@@ -87,7 +87,7 @@ RSpec.describe H3 do
       let(:count) { 6 }
 
       it "has six expected edges" do
-        expect(h3_unidirectional_edges_from_hexagon.count).to eq(count)
+        expect(unidirectional_edges_from_hexagon.count).to eq(count)
       end
     end
 
@@ -96,21 +96,21 @@ RSpec.describe H3 do
       let(:count) { 5 }
 
       it "has five expected edges" do
-        expect(h3_unidirectional_edges_from_hexagon.count).to eq(count)
+        expect(unidirectional_edges_from_hexagon.count).to eq(count)
       end
     end
   end
 
-  describe ".h3_unidirectional_edge_boundary" do
+  describe ".unidirectional_edge_boundary" do
     let(:edge) { "11928308280fffff".to_i(16) }
     let(:expected) do
       [[37.77820687262237, -122.41971895414808], [37.77652420699321, -122.42079024541876]]
     end
 
-    subject(:h3_unidirectional_edge_boundary) { H3.h3_unidirectional_edge_boundary(edge) }
+    subject(:unidirectional_edge_boundary) { H3.unidirectional_edge_boundary(edge) }
 
     it "matches expected coordinates" do
-      h3_unidirectional_edge_boundary.zip(expected) do |(lat, lon), (exp_lat, exp_lon)|
+      unidirectional_edge_boundary.zip(expected) do |(lat, lon), (exp_lat, exp_lon)|
         expect(lat).to be_within(0.000001).of(exp_lat)
         expect(lon).to be_within(0.000001).of(exp_lon)
       end


### PR DESCRIPTION
Addresses #58 

Some of the method names could be simplified, in keeping with the Ruby naming conventions.

## Changes

Still thinking about some of these 🤔 

* `h3_to_parent` => `parent`
* `max_h3_to_children_size` => `max_children`
* `h3_to_children` => `children`
* `h3_resolution` => `resolution`
* `h3_base_cell` => `base_cell`
* `string_to_h3` => `from_string`
* `h3_pentagon?` => `pentagon?`
* `h3_res_class_3?` => `class_3_resolution?`
* `h3_valid?` => `valid?`
* `h3_to_string` => `to_string`
* `h3_faces` => `faces`
* `geo_to_h3` => `from_geo_coordinates`
* `h3_to_geo` => `to_geo_coordinates`
* `h3_to_geo_boundary` => `to_boundary`
* `num_hexagons` => `hexagon_count`
* `res_0_index_count` => `base_cell_count`
* `res_0_indexes` => `base_cells`
* `h3_distance` => `distance`
* `h3_line_size` => `line_size`
* `h3_line` => `line`
* `h3_indexes_neighbors?` => `neighbors?`
* `h3_unidirectional_edge_valid?` => `unidirectional_edge_valid?`
* `h3_unidirectional_edge` => `unidirectional_edge`
* `h3_indexes_from_unidirectional_edge` => `origin_and_destination_from_unidirectional_edge`
* `h3_unidirectional_edges_from_hexagon` => `unidirectional_edges_from_hexagon`
* `h3_unidirectional_edge_boundary` => `unidirectional_edge_boundary`