### PR TITLE
Upgrade to v3.6.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    h3 (3.6.0)
+    h3 (3.6.1)
       ffi (~> 1.9)
       rgeo-geojson (~> 2.1)
       zeitwerk (~> 2.1)
@@ -17,10 +17,10 @@ GEM
       tins (~> 1.6)
     diff-lcs (1.3)
     docile (1.3.1)
-    ffi (1.11.1)
+    ffi (1.11.2)
     json (2.1.0)
     rake (12.3.2)
-    rgeo (2.1.0)
+    rgeo (2.1.1)
     rgeo-geojson (2.1.1)
       rgeo (>= 1.0.0)
     rspec (3.8.0)
@@ -46,7 +46,7 @@ GEM
     thor (0.19.4)
     tins (1.20.2)
     yard (0.9.20)
-    zeitwerk (2.1.9)
+    zeitwerk (2.2.1)
 
 PLATFORMS
   ruby

--- a/lib/h3/version.rb
+++ b/lib/h3/version.rb
@@ -1,3 +1,3 @@
 module H3
-  VERSION = "3.6.0".freeze
+  VERSION = "3.6.1".freeze
 end

--- a/spec/region_spec.rb
+++ b/spec/region_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe H3 do
       File.read(File.join(File.dirname(__FILE__), "support/fixtures/banbury.json"))
     end
     let(:resolution) { 9 }
-    let(:expected_count) { 33_391 }
+    let(:expected_count) { 36_193 }
 
     subject(:max_polyfill_size) { H3.max_polyfill_size(geojson, resolution) }
 


### PR DESCRIPTION
Includes various fixes:

- `compact` handles zero length input correctly.
- `bboxHexRadius` scaling factor adjusted to guarantee containment for `polyfill`.
- `polyfill` new algorithm for up to 3x perf boost.

https://github.com/uber/h3/releases/tag/v3.6.1