### PR TITLE
Tidy up creation of predicate methods.

### DIFF
--- a/lib/h3/bindings/base.rb
+++ b/lib/h3/bindings/base.rb
@@ -18,6 +18,20 @@ module H3
         base.typedef :pointer, :output_buffer
         base.const_set("H3_INDEX", :ulong_long)
       end
+
+      def attach_predicate_function(name, *args)
+        stripped_name = name.to_s.gsub("?", "")
+        attach_function(stripped_name, *args).tap do
+          rename_function stripped_name, name
+        end
+      end
+
+      private
+
+      def rename_function(from, to)
+        alias_method to, from
+        undef_method from
+      end
     end
   end
 end

--- a/lib/h3/inspection.rb
+++ b/lib/h3/inspection.rb
@@ -76,9 +76,7 @@ module H3
     #   true
     #
     # @return [Boolean] True if the H3 index is a pentagon.
-    attach_function :pentagon, :h3IsPentagon, %i[h3_index], :bool
-    alias_method :pentagon?, :pentagon
-    undef_method :pentagon
+    attach_predicate_function :pentagon?, :h3IsPentagon, %i[h3_index], :bool
 
     # @deprecated Please use {#pentagon?} instead.
     def h3_pentagon?(h3_index)
@@ -98,9 +96,7 @@ module H3
     #   true
     #
     # @return [Boolean] True if the H3 index has a class III resolution.
-    attach_function :class_3_resolution, :h3IsResClassIII, %i[h3_index], :bool
-    alias_method :class_3_resolution?, :class_3_resolution
-    undef_method :class_3_resolution
+    attach_predicate_function :class_3_resolution?, :h3IsResClassIII, %i[h3_index], :bool
 
     # @deprecated Please use {#class_3_resolution?} instead.
     def h3_res_class_3?(h3_index)
@@ -119,9 +115,7 @@ module H3
     #   true
     #
     # @return [Boolean] True if the H3 index is valid.
-    attach_function :valid, :h3IsValid, %i[h3_index], :bool
-    alias_method :valid?, :valid
-    undef_method :valid
+    attach_predicate_function :valid?, :h3IsValid, %i[h3_index], :bool
 
     # @deprecated Please use {#valid?} instead.
     def h3_valid?(h3_index)

--- a/lib/h3/unidirectional_edges.rb
+++ b/lib/h3/unidirectional_edges.rb
@@ -17,9 +17,7 @@ module H3
     #   true
     #
     # @return [Boolean] True if indexes are neighbors
-    attach_function :neighbors, :h3IndexesAreNeighbors, %i[h3_index h3_index], :bool
-    alias_method :neighbors?, :neighbors
-    undef_method :neighbors
+    attach_predicate_function :neighbors?, :h3IndexesAreNeighbors, %i[h3_index h3_index], :bool
 
     # @deprecated Please use {#neighbors?} instead.
     def h3_indexes_neighbors?(origin, destination)
@@ -39,12 +37,10 @@ module H3
     #   true
     #
     # @return [Boolean] True if H3 index is a valid unidirectional edge
-    attach_function :unidirectional_edge_valid,
-                    :h3UnidirectionalEdgeIsValid,
-                    %i[h3_index],
-                    :bool
-    alias_method :unidirectional_edge_valid?, :unidirectional_edge_valid
-    undef_method :unidirectional_edge_valid
+    attach_predicate_function :unidirectional_edge_valid?,
+                              :h3UnidirectionalEdgeIsValid,
+                              %i[h3_index],
+                              :bool
 
     # @deprecated Please use {#unidirectional_edge_valid?} instead.
     def h3_unidirectional_edge_valid?(h3_index)


### PR DESCRIPTION
This can be simplified with a method in the base class.